### PR TITLE
Change JSON source to one with WBC games

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def todaysGames(game_day):
     
     #addPlaylist(date_display,display_day,'/playhighlights',999,ICON,FANART)
 
-    url = 'http://gdx.mlb.com/components/game/mlb/'+url_game_day+'/grid_ce.json'    
+    url = 'http://gdx.mlb.com/components/game/mlb/'+url_game_day+'/grid.json'    
     print "URL GAME DAY"
     print url
 
@@ -216,7 +216,7 @@ def createGameListItem(game, game_day):
 def streamSelect(event_id, gid, teams_stream, stream_date):    
     display_day = stringToDate(stream_date, "%Y-%m-%d")
     url_game_day = display_day.strftime('year_%Y/month_%m/day_%d')
-    url = 'http://gdx.mlb.com/components/game/mlb/'+url_game_day+'/grid_ce.json'    
+    url = 'http://gdx.mlb.com/components/game/mlb/'+url_game_day+'/grid.json'    
     
     req = urllib2.Request(url)    
     req.add_header('Connection', 'close')


### PR DESCRIPTION
World Baseball Classic 2017 games are not showing up in the Kodi plugin. When I change the JSON URL for games, they show up and play in Kodi.

I'm not very familiar with the plugin, so unfortunately I have no idea if this change introduces other negative consequences.