### PR TITLE
added seek in live games, start live from beginning options

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ game_pk = None
 gid = None
 teams_stream = None
 stream_date = None
-spoiler = True
+spoiler = 'True'
 
 if 'name' in params:
     name = urllib.unquote_plus(params["name"])

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ game_pk = None
 gid = None
 teams_stream = None
 stream_date = None
+spoiler = True
 
 if 'name' in params:
     name = urllib.unquote_plus(params["name"])
@@ -27,6 +28,9 @@ if 'teams_stream' in params:
 if 'stream_date' in params:
     stream_date = urllib.unquote_plus(params["stream_date"])
 
+if 'spoiler' in params:
+    spoiler = urllib.unquote_plus(params["spoiler"])
+
 if mode is None:
     categories()
 
@@ -39,7 +43,7 @@ elif mode == 101:
 
 
 elif mode == 104:
-    stream_select(game_pk)
+    stream_select(game_pk, spoiler)
 
 elif mode == 105:
     # Yesterday's Games

--- a/resources/lib/account.py
+++ b/resources/lib/account.py
@@ -130,10 +130,17 @@ class Account:
             dialog.notification(LOCAL_STRING(30270), msg, self.icon, 5000, False)
             sys.exit()
 
-        offset_index = 0
-        if r.json()['data']['Airings'][0]['milestones'][0]['milestoneTime'][1]['type'] == 'offset':
-            offset_index = 1
-        broadcast_start = r.json()['data']['Airings'][0]['milestones'][0]['milestoneTime'][offset_index]['start']
+        broadcast_start = '1'
+        try:
+            offset_index = 0
+            if r.json()['data']['Airings'][0]['milestones'][0]['milestoneTime'][1]['type'] == 'offset':
+                offset_index = 1
+            broadcast_start = r.json()['data']['Airings'][0]['milestones'][0]['milestoneTime'][offset_index]['start']
+            if isinstance(broadcast_start, int):
+                broadcast_start = str(broadcast_start)
+        except:
+            pass
+        
         return auth, r.json()['data']['Airings'][0]['playbackUrls'][0]['href'], broadcast_start
 
     def get_stream(self, content_id):

--- a/resources/lib/account.py
+++ b/resources/lib/account.py
@@ -153,10 +153,10 @@ class Account:
             dialog.notification(LOCAL_STRING(30270), msg, self.icon, 5000, False)
             sys.exit()
 
-        if 'slide' in r.json()['stream']:
-            stream_url = r.json()['stream']['slide']
-        else:
+        if 'complete' in r.json()['stream']:
             stream_url = r.json()['stream']['complete']
+        else:
+            stream_url = r.json()['stream']['slide']
 
         if QUALITY == 'Always Ask':
             stream_url = self.get_stream_quality(stream_url)

--- a/resources/lib/account.py
+++ b/resources/lib/account.py
@@ -130,10 +130,14 @@ class Account:
             dialog.notification(LOCAL_STRING(30270), msg, self.icon, 5000, False)
             sys.exit()
 
-        return auth, r.json()['data']['Airings'][0]['playbackUrls'][0]['href']
+        offset_index = 0
+        if r.json()['data']['Airings'][0]['milestones'][0]['milestoneTime'][1]['type'] == 'offset':
+            offset_index = 1
+        broadcast_start = r.json()['data']['Airings'][0]['milestones'][0]['milestoneTime'][offset_index]['start']
+        return auth, r.json()['data']['Airings'][0]['playbackUrls'][0]['href'], broadcast_start
 
     def get_stream(self, content_id):
-        auth, url = self.get_playback_url(content_id)
+        auth, url, broadcast_start = self.get_playback_url(content_id)
 
         url = url.replace('{scenario}','browser~csai')
         headers = {
@@ -177,7 +181,7 @@ class Account:
         elif CDN == 'Level 3' and l3c_url not in stream_url:
             stream_url = stream_url.replace(akc_url, l3c_url)
         
-        return stream_url, headers
+        return stream_url, headers, broadcast_start
 
     def get_stream_quality(self, stream_url):
         #Check if inputstream adaptive is on, if so warn user and return master m3u8

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -178,7 +178,7 @@ def get_params():
     return param
 
 
-def add_stream(name, title, game_pk, icon=None, fanart=None, info=None, video_info=None, audio_info=None, stream_date=None, spoiler=True):
+def add_stream(name, title, game_pk, icon=None, fanart=None, info=None, video_info=None, audio_info=None, stream_date=None, spoiler='True'):
     ok=True
     u=sys.argv[0]+"?mode="+str(104)+"&name="+urllib.quote_plus(name)+"&game_pk="+urllib.quote_plus(str(game_pk))+"&stream_date="+urllib.quote_plus(str(stream_date))+"&spoiler="+urllib.quote_plus(str(spoiler))
 
@@ -458,7 +458,7 @@ def load_cookies():
     return cj
 
 
-def stream_to_listitem(stream_url, headers, spoiler=True):
+def stream_to_listitem(stream_url, headers, spoiler='True', start='1'):
     if xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)'):
         listitem = xbmcgui.ListItem(path=stream_url)
         if KODI_VERSION >= 19:
@@ -469,8 +469,8 @@ def stream_to_listitem(stream_url, headers, spoiler=True):
         listitem.setProperty('inputstream.adaptive.stream_headers', headers)
         listitem.setProperty('inputstream.adaptive.license_key', "|" + headers)
         if spoiler == "False":
-            listitem.setProperty('ResumeTime', '1')
-            listitem.setProperty('TotalTime', '1')
+            listitem.setProperty('ResumeTime', start)
+            listitem.setProperty('TotalTime', start)
     else:
         listitem = xbmcgui.ListItem(path=stream_url + '|' + headers)
 

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -178,9 +178,9 @@ def get_params():
     return param
 
 
-def add_stream(name, title, game_pk, icon=None, fanart=None, info=None, video_info=None, audio_info=None, stream_date=None):
+def add_stream(name, title, game_pk, icon=None, fanart=None, info=None, video_info=None, audio_info=None, stream_date=None, spoiler=True):
     ok=True
-    u=sys.argv[0]+"?mode="+str(104)+"&name="+urllib.quote_plus(name)+"&game_pk="+urllib.quote_plus(str(game_pk))+"&stream_date="+urllib.quote_plus(str(stream_date))
+    u=sys.argv[0]+"?mode="+str(104)+"&name="+urllib.quote_plus(name)+"&game_pk="+urllib.quote_plus(str(game_pk))+"&stream_date="+urllib.quote_plus(str(stream_date))+"&spoiler="+urllib.quote_plus(str(spoiler))
 
     liz=xbmcgui.ListItem(name)
     if icon is None: icon = ICON
@@ -458,7 +458,7 @@ def load_cookies():
     return cj
 
 
-def stream_to_listitem(stream_url, headers):
+def stream_to_listitem(stream_url, headers, spoiler=True):
     if xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)'):
         listitem = xbmcgui.ListItem(path=stream_url)
         if KODI_VERSION >= 19:
@@ -468,6 +468,9 @@ def stream_to_listitem(stream_url, headers):
         listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')
         listitem.setProperty('inputstream.adaptive.stream_headers', headers)
         listitem.setProperty('inputstream.adaptive.license_key', "|" + headers)
+        if spoiler == "False":
+            listitem.setProperty('ResumeTime', '1')
+            listitem.setProperty('TotalTime', '1')
     else:
         listitem = xbmcgui.ListItem(path=stream_url + '|' + headers)
 

--- a/resources/lib/mlb.py
+++ b/resources/lib/mlb.py
@@ -139,9 +139,9 @@ def create_game_listitem(game, game_day):
     stream_date = str(game_day)
 
     desc = ''
-    spoiler = True
+    spoiler = 'True'
     if NO_SPOILERS == '1' or (NO_SPOILERS == '2' and fav_game) or (NO_SPOILERS == '3' and game_day == localToEastern()) or (NO_SPOILERS == '4' and game_day < localToEastern()) or game['status']['abstractGameState'] == 'Preview':
-        spoiler = False
+        spoiler = 'False'
         name = game_time + ' ' + away_team + ' at ' + home_team
     else:
         name = game_time + ' ' + away_team
@@ -194,7 +194,7 @@ def create_game_listitem(game, game_day):
     add_stream(name, title, game_pk, icon, fanart, info, video_info, audio_info, stream_date, spoiler)
 
 
-def stream_select(game_pk, spoiler=True):
+def stream_select(game_pk, spoiler='True'):
     url = 'https://statsapi.mlb.com/api/v1/game/' + game_pk + '/content'
     headers = {
         'User-Agent': UA_ANDROID
@@ -234,12 +234,13 @@ def stream_select(game_pk, spoiler=True):
         sys.exit()
 
     stream_url = ''
+    start = '1'
 
     dialog = xbmcgui.Dialog()
     n = dialog.select('Choose Stream', stream_title)
     if n > -1 and stream_title[n] != 'Highlights':
         account = Account()
-        stream_url, headers = account.get_stream(content_id[n-highlight_offset])
+        stream_url, headers, broadcast_start = account.get_stream(content_id[n-highlight_offset])
         if sys.argv[3] == 'resume:true':
             spoiler = "True"
         elif epg[0]['mediaState'] == "MEDIA_ON" and CATCH_UP == 'true':
@@ -250,13 +251,14 @@ def stream_select(game_pk, spoiler=True):
                 sys.exit()
             elif p == 1:
                 spoiler = "False"
+                start = broadcast_start
             elif p == 2:
                 spoiler = "True"
             elif p == -1:
                 sys.exit()
 
     if '.m3u8' in stream_url:
-        play_stream(stream_url, headers, spoiler)
+        play_stream(stream_url, headers, spoiler, start)
 
     elif stream_title[n] == 'Highlights':
         highlight_select_stream(json_source['highlights']['highlights']['items'])
@@ -305,8 +307,8 @@ def highlight_select_stream(json_source, catchup=None):
         xbmcplugin.setResolvedUrl(handle=addon_handle, succeeded=True, listitem=playlist[0])
 
 
-def play_stream(stream_url, headers, spoiler=True):
-    listitem = stream_to_listitem(stream_url, headers, spoiler)
+def play_stream(stream_url, headers, spoiler='True', start='1'):
+    listitem = stream_to_listitem(stream_url, headers, spoiler, start)
     xbmcplugin.setResolvedUrl(handle=addon_handle, succeeded=True, listitem=listitem)
 
 

--- a/resources/lib/mlb.py
+++ b/resources/lib/mlb.py
@@ -202,7 +202,10 @@ def stream_select(game_pk, spoiler=True):
     r = requests.get(url, headers=headers, verify=VERIFY)
     json_source = r.json()
 
-    stream_title = ['Highlights']
+    if sys.argv[3] == 'resume:true':
+        stream_title = []
+    else:
+        stream_title = ['Highlights']
     media_state = []
     content_id = []
     epg = json_source['media']['epg'][0]['items']
@@ -235,7 +238,9 @@ def stream_select(game_pk, spoiler=True):
     if n > -1 and stream_title[n] != 'Highlights':
         account = Account()
         stream_url, headers = account.get_stream(content_id[n-1])
-        if epg[0]['mediaState'] == "MEDIA_ON" and CATCH_UP == 'true':
+        if sys.argv[3] == 'resume:true':
+            spoiler = "True"
+        elif epg[0]['mediaState'] == "MEDIA_ON" and CATCH_UP == 'true':
             p = dialog.select('Select a Start Point', ['Catch Up', 'Beginning', 'Live'])
             if p == 0:
                 listitem = stream_to_listitem(stream_url, headers)

--- a/resources/lib/mlb.py
+++ b/resources/lib/mlb.py
@@ -315,7 +315,7 @@ def play_stream(stream_url, headers, spoiler='True', start='1'):
 def get_highlights(items):
     xbmc.log(str(items))
     highlights = []
-    for item in items:
+    for item in sorted(items, key=lambda x: x['date']):
         for playback in item['playbacks']:
             if 'hlsCloud' in playback['name']:
                 clip_url = playback['url']

--- a/resources/lib/mlb.py
+++ b/resources/lib/mlb.py
@@ -204,8 +204,10 @@ def stream_select(game_pk, spoiler=True):
 
     if sys.argv[3] == 'resume:true':
         stream_title = []
+        highlight_offset = 0
     else:
         stream_title = ['Highlights']
+        highlight_offset = 1
     media_state = []
     content_id = []
     epg = json_source['media']['epg'][0]['items']
@@ -218,7 +220,7 @@ def stream_select(game_pk, spoiler=True):
                 if 'HOME' in title.upper():
                     media_state.insert(0, item['mediaState'])
                     content_id.insert(0, item['contentId'])
-                    stream_title.insert(1, title + " (" + item['callLetters'] + ")")
+                    stream_title.insert(highlight_offset, title + " (" + item['callLetters'] + ")")
                 else:
                     media_state.append(item['mediaState'])
                     content_id.append(item['contentId'])
@@ -237,7 +239,7 @@ def stream_select(game_pk, spoiler=True):
     n = dialog.select('Choose Stream', stream_title)
     if n > -1 and stream_title[n] != 'Highlights':
         account = Account()
-        stream_url, headers = account.get_stream(content_id[n-1])
+        stream_url, headers = account.get_stream(content_id[n-highlight_offset])
         if sys.argv[3] == 'resume:true':
             spoiler = "True"
         elif epg[0]['mediaState'] == "MEDIA_ON" and CATCH_UP == 'true':

--- a/resources/lib/mlb.py
+++ b/resources/lib/mlb.py
@@ -247,7 +247,7 @@ def stream_select(game_pk, spoiler='True'):
             p = dialog.select('Select a Start Point', ['Catch Up', 'Beginning', 'Live'])
             if p == 0:
                 listitem = stream_to_listitem(stream_url, headers)
-                highlight_select_stream(json_source['highlights']['live']['items'], listitem)
+                highlight_select_stream(json_source['highlights']['highlights']['items'], listitem)
                 sys.exit()
             elif p == 1:
                 spoiler = "False"


### PR DESCRIPTION
- Changed default live stream from "slide" to "complete" so it's now possible to seek/pause within live streams.
- Added variable to track spoiler status for individual games, from create_game_listitem to play_stream (False means no spoiler)
- If "no spoiler" is set for a requested live game, it will start playing from the beginning using the broadcast start time (unless "Catch Up" is enabled, then the user can choose between "Catch Up", "Beginning", or "Live" for all live games).
- Hide "Highlights" option, and Catch Up/Beginning/Live dialog, if a Kodi resume point has been selected

Question: the "Catch Up" option doesn't work for me, although I've never used it before either. Is it just supposed to show highlights in order? If it's not functional anymore, maybe the setting could be re-named -- an "Always Ask" for starting live games either Beginning or Live?