### PR TITLE
pad video to avoid timeline spoilers, autoplay fav team option, etc.

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.5.6" provider-name="eracknaphobia">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.5.19" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.pytz" />
@@ -12,6 +12,7 @@
     <extension point="xbmc.python.pluginsource" library="main.py">
         <provides>video</provides>
     </extension>
+    <extension point="xbmc.service" library="service.py" start="login" />
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
         <summary lang="en_GB">Watch live and archived games
@@ -21,10 +22,12 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - restored pass exceptions for game list items
-            - handle missing flags for postponements
-            - added setting for auto selecting a stream (favorite/home)
-            - added context menu item for choosing stream manually
+            - pad the end of archive videos if no spoilers (to avoid timeline spoilers)
+            - autoplay favorite team setting
+            - see scores at inning category
+            - hide bottom of 9th / extra innings as spoilers
+            - labels for suspended/resumed games/streams
+            - retain icon/fanart/probables through context menu navigation
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/main.py
+++ b/main.py
@@ -9,7 +9,12 @@ gid = None
 teams_stream = None
 stream_date = None
 spoiler = 'True'
+suspended = 'False'
+start_inning = 'False'
+icon = None
+fanart = None
 featured_video = None
+description = None
 
 if 'name' in params:
     name = urllib.unquote_plus(params["name"])
@@ -32,49 +37,92 @@ if 'stream_date' in params:
 if 'spoiler' in params:
     spoiler = urllib.unquote_plus(params["spoiler"])
 
+if 'suspended' in params:
+    suspended = urllib.unquote_plus(params["suspended"])
+
+if 'icon' in params:
+    icon = urllib.unquote_plus(params["icon"])
+
+if 'fanart' in params:
+    fanart = urllib.unquote_plus(params["fanart"])
+
+if 'start_inning' in params:
+    start_inning = urllib.unquote_plus(params["start_inning"])
+
 if 'featured_video' in params:
     featured_video = urllib.unquote_plus(params["featured_video"])
 
+if 'description' in params:
+    description = urllib.unquote_plus(params["description"])
+
+# default addon home screen
 if mode is None:
+    # autoplay fav team, if that setting is enabled and a live broadcast is in progress
+    if AUTO_PLAY_FAV == 'true' and FAV_TEAM != 'None':
+        live_game = live_fav_game()
+        if live_game is not None:
+            xbmc.log('Auto-playing live game ' + str(live_game))
+            xbmc.executebuiltin('PlayMedia("plugin://plugin.video.mlbtv/?mode=102&game_pk='+str(live_game)+'")')
+            xbmcplugin.endOfDirectory(addon_handle)
+    # if no autoplay, show the main options
     categories()
 
+# Today's Games
 elif mode == 100:
-    todays_games(None)
+    todays_games(None, start_inning)
 
+# Prev and Next
 elif mode == 101:
-    # Prev and Next
-    todays_games(game_day)
+    todays_games(game_day, start_inning)
+
+# autoplay, use an extra parameter to force auto stream selection
+elif mode == 102:
+    stream_select(game_pk, spoiler, suspended, start_inning, description, name, icon, fanart, autoplay=True)
 
 # from context menu, use an extra parameter to force manual stream selection
 elif mode == 103:
-    stream_select(game_pk, spoiler, True)
+    stream_select(game_pk, spoiler, suspended, start_inning, description, name, icon, fanart, from_context_menu=True)
 
+# normal stream selection
 elif mode == 104:
-    stream_select(game_pk, spoiler)
+    stream_select(game_pk, spoiler, suspended, start_inning, description, name, icon, fanart)
 
+# Yesterday's Games
 elif mode == 105:
-    # Yesterday's Games
-    game_day = localToEastern()
-    display_day = stringToDate(game_day, "%Y-%m-%d")
-    prev_day = display_day - timedelta(days=1)
-    todays_games(prev_day.strftime("%Y-%m-%d"))
+    todays_games(yesterdays_date(), start_inning)
 
 # highlights from context menu
 elif mode == 106:
-    list_highlights(game_pk)
+    list_highlights(game_pk, icon, fanart)
 
 # play all highlights for game from context menu
 elif mode == 107:
-    play_all_highlights_for_game(game_pk)
+    play_all_highlights_for_game(game_pk, fanart)
 
+# see yesterday's scores at inning
+elif mode == 108:
+    start_inning = 'False'
+    dialog = xbmcgui.Dialog()
+    innings = []
+    # show inning options from 1 to 12
+    for x in range(1, 13):
+        innings.append(LOCAL_STRING(30407) + ' ' + str(x))
+    n = dialog.select(LOCAL_STRING(30413), innings)
+    if n > -1:
+        start_inning = (n + 1)
+    game_day = yesterdays_date()
+    # Refresh will erase history, so navigating back won't bring up the inning prompt again
+    xbmc.executebuiltin('Container.Refresh("plugin://plugin.video.mlbtv/?mode=101&game_day='+game_day+'&start_inning='+str(start_inning)+'")')
+
+# Goto Date
 elif mode == 200:
-    # Goto Date
     search_txt = ''
     dialog = xbmcgui.Dialog()
     game_day = dialog.input('Enter date (yyyy-mm-dd)', type=xbmcgui.INPUT_ALPHANUM)
     mat = re.match('(\d{4})-(\d{2})-(\d{2})$', game_day)
     if mat is not None:
-        todays_games(game_day)
+        # Refresh will erase history, so navigating back won't bring up the date prompt again
+        xbmc.executebuiltin('Container.Refresh("plugin://plugin.video.mlbtv/?mode=101&game_day='+game_day+'&start_inning='+str(start_inning)+'")')
     else:
         if game_day != '':
             dialog = xbmcgui.Dialog()
@@ -82,28 +130,32 @@ elif mode == 200:
 
         sys.exit()
 
+# Featured Videos
 elif mode == 300:
-    # Featured Videos
     featured_videos(featured_video)
 
+# Featured stream select
 elif mode == 301:
-    featured_stream_select(featured_video, name)
+    featured_stream_select(featured_video, name, description)
 
+# Logout
 elif mode == 400:
     account = Account()
     account.logout()
     dialog = xbmcgui.Dialog()
     dialog.notification(LOCAL_STRING(30260), LOCAL_STRING(30261), ICON, 5000, False)
 
+# play all recaps or condensed games for selected date
 elif mode == 900:
-    # play all recaps or condensed games for selected date
     playAllHighlights(stream_date)
 
 elif mode == 999:
     sys.exit()
 
-if mode == 100:
+# don't cache today's games or addon home screen
+if mode == 100 or (mode is None and AUTO_PLAY_FAV == 'true' and FAV_TEAM != 'None'):
     xbmcplugin.endOfDirectory(addon_handle, cacheToDisc=False)
+# also don't cache previous/next days
 elif mode == 101:
     xbmcplugin.endOfDirectory(addon_handle, cacheToDisc=False, updateListing=True)
 else:

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -335,3 +335,11 @@ msgstr ""
 msgctxt "#30411"
 msgid "Play All"
 msgstr ""
+
+msgctxt "#30412"
+msgid "Auto-play live favorite games when starting addon"
+msgstr ""
+
+msgctxt "#30413"
+msgid "See Yesterday's Scores at inning"
+msgstr ""

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -6,6 +6,7 @@ from datetime import date, datetime, timedelta
 from dateutil.parser import parse
 import json
 from kodi_six import xbmc, xbmcvfs, xbmcplugin, xbmcgui, xbmcaddon
+import random
 
 if sys.version_info[0] > 2:
     import http
@@ -48,6 +49,7 @@ SINGLE_TEAM = str(settings.getSetting(id='single_team'))
 AUTO_SELECT_STREAM = str(settings.getSetting(id='auto_select_stream'))
 CATCH_UP = str(settings.getSetting(id='catch_up'))
 ASK_TO_SKIP = str(settings.getSetting(id='ask_to_skip'))
+AUTO_PLAY_FAV = str(settings.getSetting(id='auto_play_fav'))
 ONLY_FREE_GAMES = str(settings.getSetting(id="only_free_games"))
 
 #Monitor setting
@@ -100,8 +102,8 @@ UA_ANDROID = 'okhttp/3.12.1'
 VERIFY = True
 
 #Skip monitor
-#These are the break events to ignore
-BREAK_TYPES = ['Game Advisory', 'Pitching Substitution', 'Offensive Substitution', 'Defensive Sub', 'Defensive Switch', 'Runner Placed On Base']
+#These are the break events to skip
+BREAK_TYPES = ['Game Advisory', 'Pitching Substitution', 'Offensive Substitution', 'Defensive Sub', 'Defensive Switch', 'Runner Placed On Base', 'Injury']
 #These are the action events to keep, in addition to the last event of each at-bat, if we're skipping non-decision pitches
 ACTION_TYPES = ['Wild Pitch', 'Passed Ball', 'Stolen Base', 'Caught Stealing', 'Pickoff', 'Error', 'Out', 'Balk', 'Defensive Indiff']
 #Pad events at both start (-) and end (+)
@@ -153,18 +155,9 @@ def UTCToLocal(utc_dt):
     return local_dt.replace(microsecond=utc_dt.microsecond)
 
 
-def localToEastern():    
-    eastern = pytz.timezone('US/Eastern')    
-    local_to_utc = datetime.now(pytz.timezone('UTC'))  
+def localToEastern():
+    return get_eastern_game_date(datetime.now(pytz.timezone('UTC')))
 
-    eastern_hour = local_to_utc.astimezone(eastern).strftime('%H')    
-    eastern_date = local_to_utc.astimezone(eastern)
-    #Don't switch to the current day until 4:01 AM est
-    if int(eastern_hour) < 3:
-        eastern_date = eastern_date - timedelta(days=1)  
-
-    local_to_eastern = eastern_date.strftime('%Y-%m-%d')
-    return local_to_eastern
 
 def easternToUTC(eastern_time):    
     utc = pytz.utc
@@ -173,6 +166,23 @@ def easternToUTC(eastern_time):
     # Convert it from Eastern to UTC
     utc_time = eastern_time.astimezone(utc)
     return utc_time
+
+
+def get_eastern_game_date(timestamp):
+    eastern = pytz.timezone('US/Eastern')
+    eastern_hour = timestamp.astimezone(eastern).strftime('%H')
+    eastern_date = timestamp.astimezone(eastern)
+    #Don't switch to the current day until 4:01 AM est
+    if int(eastern_hour) < 3:
+        eastern_date = eastern_date - timedelta(days=1)
+    return eastern_date.strftime('%Y-%m-%d')
+
+
+def yesterdays_date():
+    game_day = localToEastern()
+    display_day = stringToDate(game_day, "%Y-%m-%d")
+    prev_day = display_day - timedelta(days=1)
+    return prev_day.strftime("%Y-%m-%d")
 
 
 def get_params():
@@ -194,9 +204,10 @@ def get_params():
     return param
 
 
-def add_stream(name, title, game_pk, icon=None, fanart=None, info=None, video_info=None, audio_info=None, stream_date=None, spoiler='True'):
+def add_stream(name, title, desc, game_pk, icon=None, fanart=None, info=None, video_info=None, audio_info=None, stream_date=None, spoiler='True', suspended=None, start_inning='False'):
     ok=True
-    u=sys.argv[0]+"?mode="+str(104)+"&name="+urllib.quote_plus(name)+"&game_pk="+urllib.quote_plus(str(game_pk))+"&stream_date="+urllib.quote_plus(str(stream_date))+"&spoiler="+urllib.quote_plus(str(spoiler))
+    u_params = "&name="+urllib.quote_plus(title)+"&game_pk="+urllib.quote_plus(str(game_pk))+"&stream_date="+urllib.quote_plus(str(stream_date))+"&spoiler="+urllib.quote_plus(str(spoiler))+"&suspended="+urllib.quote_plus(str(suspended))+"&start_inning="+urllib.quote_plus(str(start_inning))+"&description="+urllib.quote_plus(desc)
+    u=sys.argv[0]+"?mode="+str(104)+u_params
 
     liz=xbmcgui.ListItem(name)
     if icon is None: icon = ICON
@@ -212,7 +223,8 @@ def add_stream(name, title, game_pk, icon=None, fanart=None, info=None, video_in
         liz.addStreamInfo('audio', audio_info)
 
     # add Choose Stream and Highlights as context menu items
-    liz.addContextMenuItems([(LOCAL_STRING(30390), 'PlayMedia(plugin://plugin.video.mlbtv/?mode='+str(103)+'&name='+urllib.quote_plus(name)+'&game_pk='+urllib.quote_plus(str(game_pk))+'&stream_date='+urllib.quote_plus(str(stream_date))+'&spoiler='+urllib.quote_plus(str(spoiler))+')'), (LOCAL_STRING(30391), 'Container.Update(plugin://plugin.video.mlbtv/?mode='+str(106)+'&name='+urllib.quote_plus(name)+'&game_pk='+urllib.quote_plus(str(game_pk))+')')])
+    art_params = "&icon="+urllib.quote_plus(icon)+"&fanart="+urllib.quote_plus(fanart)
+    liz.addContextMenuItems([(LOCAL_STRING(30390), 'PlayMedia(plugin://plugin.video.mlbtv/?mode='+str(103)+u_params+art_params+')'), (LOCAL_STRING(30391), 'Container.Update(plugin://plugin.video.mlbtv/?mode='+str(106)+'&name='+urllib.quote_plus(title)+'&game_pk='+urllib.quote_plus(str(game_pk))+art_params+')')])
 
     ok=xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=u,listitem=liz,isFolder=False)
     xbmcplugin.setContent(addon_handle, 'episodes')
@@ -247,12 +259,13 @@ def addLink(name,url,title,icon,info=None,video_info=None,audio_info=None,fanart
     return ok
 
 
-def addDir(name,mode,icon,fanart=None,game_day=None):
+def addDir(name,mode,icon,fanart=None,game_day=None,start_inning='False'):
     ok=True
 
-    u=sys.argv[0]+"?mode="+str(mode)+"&name="+urllib.quote_plus(name)+"&icon="+urllib.quote_plus(icon)
+    u_params="&name="+urllib.quote_plus(name)+"&icon="+urllib.quote_plus(icon)+'&start_inning='+urllib.quote_plus(str(start_inning))
     if game_day is not None:
-        u = u+"&game_day="+urllib.quote_plus(game_day)
+        u_params = u_params+"&game_day="+urllib.quote_plus(game_day)
+    u=sys.argv[0]+"?mode="+str(mode)+u_params
 
     liz = xbmcgui.ListItem(name)
     if icon is None: icon = ICON
@@ -405,12 +418,12 @@ def load_cookies():
     return cj
 
 
-def stream_to_listitem(stream_url, headers, spoiler='True', start='1', stream_type='video'):
+def stream_to_listitem(stream_url, headers, description, title, icon, fanart, start='1', stream_type='video'):
     # check if our stream is HLS
     if '.m3u8' in stream_url:
         # if not audio only, check if inputstream.adaptive is present and enabled, depending on Kodi version
         if stream_type != 'audio' and (xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)') or (KODI_VERSION >= 19 and xbmc.getCondVisibility('System.AddonIsEnabled(inputstream.adaptive)'))):
-            listitem = xbmcgui.ListItem(path=stream_url)
+            listitem = xbmcgui.ListItem(title, path=stream_url)
             if KODI_VERSION >= 19:
                 listitem.setProperty('inputstream', 'inputstream.adaptive')
             else:
@@ -418,12 +431,12 @@ def stream_to_listitem(stream_url, headers, spoiler='True', start='1', stream_ty
             listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')
             listitem.setProperty('inputstream.adaptive.stream_headers', headers)
             listitem.setProperty('inputstream.adaptive.license_key', "|" + headers)
-            # start stream at beginning if no spoilers
-            if spoiler == "False":
+            # if not using Kodi's resume function, set the start time
+            if sys.argv[3] != 'resume:true' and start != '-1':
                 listitem.setProperty('ResumeTime', start)
                 listitem.setProperty('TotalTime', start)
         else:
-            listitem = xbmcgui.ListItem(path=stream_url + '|' + headers)
+            listitem = xbmcgui.ListItem(title, path=stream_url + '|' + headers)
 
         listitem.setMimeType("application/x-mpegURL")
     # otherwise, if not HLS, assume it is MP4
@@ -431,4 +444,57 @@ def stream_to_listitem(stream_url, headers, spoiler='True', start='1', stream_ty
         listitem = xbmcgui.ListItem(path=stream_url + '|' + headers)
         listitem.setMimeType("video/mp4")
 
+    if title is not None and description is not None:
+        if stream_type != 'audio':
+            listitem.setInfo( type="Video", infoLabels={ "Title": title, "Plot": description } )
+        else:
+            listitem.setInfo( type="Music", infoLabels={ "Title": title, "Album": description } )
+
+    if icon is not None and fanart is not None:
+        listitem.setArt({'icon': icon, 'thumb': icon, 'fanart': fanart})
+
     return listitem
+
+
+# get the airings data, which contains the start time of the broadcast(s)
+def get_airings_data(content_id=None, game_pk=None):
+    xbmc.log('Get airings data')
+    url = 'https://search-api-mlbtv.mlb.com/svc/search/v2/graphql/persisted/query/core/Airings'
+    headers = {
+        'Accept': 'application/json',
+        'X-BAMSDK-Version': '4.3',
+        'X-BAMSDK-Platform': 'macintosh',
+        'User-Agent': UA_PC,
+        'Origin': 'https://www.mlb.com',
+        'Accept-Encoding': 'gzip, deflate, br',
+        'Content-type': 'application/json'
+    }
+    if content_id is not None:
+        data = {
+            'variables': '%7B%22contentId%22%3A%22' + content_id + '%22%7D'
+        }
+    else:
+        data = {
+            'variables': '{%22partnerProgramIds%22%3A[%22' + str(game_pk) + '%22]}'
+        }
+    r = requests.get(url, headers=headers, params=data, verify=VERIFY)
+    json_source = r.json()
+
+    return json_source
+
+
+def get_inning_start_options():
+    start_options = []
+    # add start options for each inning 1-12
+    for x in range(1, 13):
+        start_options.append(LOCAL_STRING(30409) + ' ' + LOCAL_STRING(30407) + ' ' + str(x)) # top
+        start_options.append(LOCAL_STRING(30410) + ' ' + LOCAL_STRING(30407) + ' ' + str(x)) # bottom
+    return start_options
+
+
+def calculate_inning_from_index(index):
+    inning_half = 'top'
+    inning = int(round(((index+0.5) / 2), 0))
+    if (index % 2) == 0 and ((index+1) % 2) == 1:
+        inning_half = 'bottom'
+    return inning, inning_half

--- a/resources/lib/mlb.py
+++ b/resources/lib/mlb.py
@@ -6,12 +6,14 @@ from .mlbmonitor import MLBMonitor
 def categories():
     addDir(LOCAL_STRING(30360), 100, ICON, FANART)
     addDir(LOCAL_STRING(30361), 105, ICON, FANART)
+    # see yesterday's scores at inning in the main menu
+    addDir(LOCAL_STRING(30413), 108, ICON, FANART)
     addDir(LOCAL_STRING(30362), 200, ICON, FANART)
     # show Featured Videos in the main menu
     addDir(LOCAL_STRING(30363), 300, ICON, FANART)
 
 
-def todays_games(game_day):
+def todays_games(game_day, start_inning='False'):
     if game_day is None:
         game_day = localToEastern()
 
@@ -21,7 +23,7 @@ def todays_games(game_day):
     #url_game_day = display_day.strftime('year_%Y/month_%m/day_%d')
     prev_day = display_day - timedelta(days=1)
 
-    addDir('[B]<< %s[/B]' % LOCAL_STRING(30010), 101, PREV_ICON, FANART, prev_day.strftime("%Y-%m-%d"))
+    addDir('[B]<< %s[/B]' % LOCAL_STRING(30010), 101, PREV_ICON, FANART, prev_day.strftime("%Y-%m-%d"), start_inning)
 
     date_display = '[B][I]' + colorString(display_day.strftime("%A, %m/%d/%Y"), GAMETIME_COLOR) + '[/I][/B]'
 
@@ -46,15 +48,15 @@ def todays_games(game_day):
 
     try:
         for game in json_source['dates'][0]['games']:
-            create_game_listitem(game, game_day)
+            create_game_listitem(game, game_day, start_inning)
     except:
         pass
 
     next_day = display_day + timedelta(days=1)
-    addDir('[B]%s >>[/B]' % LOCAL_STRING(30011), 101, NEXT_ICON, FANART, next_day.strftime("%Y-%m-%d"))
+    addDir('[B]%s >>[/B]' % LOCAL_STRING(30011), 101, NEXT_ICON, FANART, next_day.strftime("%Y-%m-%d"), start_inning)
 
 
-def create_game_listitem(game, game_day):
+def create_game_listitem(game, game_day, start_inning):
     #icon = ICON
     icon = 'https://img.mlbstatic.com/mlb-photos/image/upload/ar_167:215,c_crop/fl_relative,l_team:' + str(game['teams']['home']['team']['id']) + ':fill:spot.png,w_1.0,h_1,x_0.5,y_0,fl_no_overflow,e_distort:100p:0:200p:0:200p:100p:0:100p/fl_relative,l_team:' + str(game['teams']['away']['team']['id']) + ':logo:spot:current,w_0.38,x_-0.25,y_-0.16/fl_relative,l_team:' + str(game['teams']['home']['team']['id']) + ':logo:spot:current,w_0.38,x_0.25,y_0.16/w_750/team/' + str(game['teams']['away']['team']['id']) + '/fill/spot.png'
     # http://mlb.mlb.com/mlb/images/devices/ballpark/1920x1080/2681.jpg
@@ -75,7 +77,6 @@ def create_game_listitem(game, game_day):
         home_team = game['teams']['home']['team']['abbreviation']
 
     title = away_team + ' at ' + home_team
-    title = title
 
     is_free = False
     if 'content' in game and 'media' in game['content'] and 'freeGame' in game['content']['media']:
@@ -91,43 +92,87 @@ def create_game_listitem(game, game_day):
         home_team = colorString(home_team, getFavTeamColor())
 
     game_time = ''
+    suspended = 'False'
+    display_time = 'TBD'
+    relative_inning = None
+    spoiler = 'True'
+    today = localToEastern()
+    if NO_SPOILERS == '1' or (NO_SPOILERS == '2' and fav_game) or (NO_SPOILERS == '3' and game_day == today) or (NO_SPOILERS == '4' and game_day < today):
+        spoiler = 'False'
+
+    if 'gameDate' in game:
+        display_time = stringToDate(game['gameDate'], "%Y-%m-%dT%H:%M:%SZ")
+        display_time = UTCToLocal(display_time)
+
+        if TIME_FORMAT == '0':
+            display_time = display_time.strftime('%I:%M %p').lstrip('0')
+        else:
+            display_time = display_time.strftime('%H:%M')
+
     #if game['status']['abstractGameState'] == 'Preview':
     if game['status']['detailedState'].lower() == 'scheduled' or game['status']['detailedState'].lower() == 'pre-game':
-        if game['status']['startTimeTBD'] == True:
+        if game['status']['startTimeTBD'] is True:
             game_time = 'TBD'
         else:
-            game_time = game['gameDate']
-            game_time = stringToDate(game_time, "%Y-%m-%dT%H:%M:%SZ")
-            game_time = UTCToLocal(game_time)
-
-            if TIME_FORMAT == '0':
-                game_time = game_time.strftime('%I:%M %p').lstrip('0')
-            else:
-                game_time = game_time.strftime('%H:%M')
+            game_time = display_time
 
         game_time = colorString(game_time, UPCOMING)
 
     else:
         #game_time = game['status']['abstractGameState']
-        game_time = game['status']['detailedState']
+        game_state = game['status']['detailedState']
+        game_time = game_state
+        scheduled_innings = 9
+        if 'linescore' in game and 'scheduledInnings' in game['linescore']:
+            scheduled_innings = int(game['linescore']['scheduledInnings'])
 
-        if game_time == 'Final':
+        if game_state != 'Postponed':
+            # if we've requested to see scores at a particular inning
+            if start_inning != 'False' and 'linescore' in game:
+                relative_inning = (int(start_inning) - (9 - scheduled_innings))
+                if relative_inning > len(game['linescore']['innings']):
+                    relative_inning = len(game['linescore']['innings'])
+                if relative_inning > 0:
+                    game_time = 'T' + str(relative_inning)
+                else:
+                    game_time = display_time
+            elif game_state != 'Final' and game['status']['abstractGameState'] == 'Live' and 'linescore' in game:
+                if game['linescore']['isTopInning']:
+                    # up triangle
+                    # top_bottom = u"\u25B2"
+                    top_bottom = "T"
+                else:
+                    # down triangle
+                    # top_bottom = u"\u25BC"
+                    top_bottom = "B"
+
+                if game['linescore']['currentInning'] >= scheduled_innings and spoiler == 'False':
+                    game_time = str(scheduled_innings) + 'th+'
+                else:
+                    game_time = top_bottom + ' ' + game['linescore']['currentInningOrdinal']
+
+            try:
+                if 'resumeGameDate' in game or 'resumedFromDate' in game:
+                    suspended = 'archive'
+                    if 'resumeGameDate' in game:
+                        game_time += ' (Suspended)'
+                    elif 'resumedFromDate' in game:
+                        game_time += ' (Resumed)'
+                    for epg in game['content']['media']['epg'][0]['items']:
+                        if epg['mediaState'] == 'MEDIA_ON':
+                            suspended = 'live'
+                            break
+                        elif epg['mediaState'] == 'MEDIA_OFF':
+                            game_time = display_time + ' ' + game_time
+                            break
+            except:
+                pass
+
+        if game_state == 'Final' or game_state == 'Postponed':
             game_time = colorString(game_time, FINAL)
 
         elif game['status']['abstractGameState'] == 'Live':
-            if game['linescore']['isTopInning']:
-                # up triangle
-                # top_bottom = u"\u25B2"
-                top_bottom = "T"
-            else:
-                # down triangle
-                # top_bottom = u"\u25BC"
-                top_bottom = "B"
-
-            inning = game['linescore']['currentInningOrdinal']
-            game_time = top_bottom + ' ' + inning
-
-            if game['linescore']['currentInning'] >= 9:
+            if 'linescore' in game and game['linescore']['currentInning'] >= scheduled_innings:
                 color = CRITICAL
             else:
                 color = LIVE
@@ -160,21 +205,38 @@ def create_game_listitem(game, game_day):
         desc += ', from ' + game['venue']['name']
     if 'description' in game and game['description'] != "":
         desc += ' (' + game['description'] + ')'
-    spoiler = 'True'
-    if NO_SPOILERS == '1' or (NO_SPOILERS == '2' and fav_game) or (NO_SPOILERS == '3' and game_day == localToEastern()) or (NO_SPOILERS == '4' and game_day < localToEastern()) or game['status']['abstractGameState'] == 'Preview':
-        spoiler = 'False'
+    if game['status']['abstractGameState'] == 'Preview' or (start_inning == 'False' and spoiler == 'False'):
         name = game_time + ' ' + away_team + ' at ' + home_team
     else:
         name = game_time + ' ' + away_team
-        if 'linescore' in game: name += ' ' + colorString(str(game['linescore']['teams']['away']['runs']), SCORE_COLOR)
-        name += ' at ' + home_team
-        if 'linescore' in game: name += ' ' + colorString(str(game['linescore']['teams']['home']['runs']), SCORE_COLOR)
+        away_score = ''
+        home_score = ''
+        try:
+            if 'linescore' in game and game_state != 'Postponed':
+                away_score = 0
+                home_score = 0
+                if relative_inning is None:
+                    away_score = game['linescore']['teams']['away']['runs']
+                    home_score = game['linescore']['teams']['home']['runs']
+                else:
+                    for inning in game['linescore']['innings']:
+                        if int(inning['num']) < relative_inning:
+                            away_score += inning['away']['runs']
+                            home_score += inning['home']['runs']
+                        else:
+                            break
+                away_score = ' ' + colorString(str(away_score), SCORE_COLOR)
+                home_score = ' ' + colorString(str(home_score), SCORE_COLOR)
+        except:
+            pass
+
+        name += away_score + ' at ' + home_team + home_score
 
         # check flags
         if 'flags' in game:
-            if game['flags']['perfectGame'] == True:
+            if game['flags']['perfectGame'] is True:
                 name += ' ' + colorString('(Perfect Game)', CRITICAL)
-            elif game['flags']['noHitter'] == True:
+            elif game['flags']['noHitter'] is True:
                 name += ' ' + colorString('(No-Hitter)', CRITICAL)
 
     if game['doubleHeader'] != 'N':
@@ -195,7 +257,7 @@ def create_game_listitem(game, game_day):
     # If set only show free games in the list
     if ONLY_FREE_GAMES == 'true' and not is_free:
         return
-    add_stream(name, title, game_pk, icon, fanart, info, video_info, audio_info, stream_date, spoiler)
+    add_stream(name, title, desc, game_pk, icon, fanart, info, video_info, audio_info, stream_date, spoiler, suspended, start_inning)
 
 
 # fetch a list of featured videos
@@ -228,10 +290,13 @@ def featured_videos(featured_video=None):
             if 'title' in item:
                 title = item['title']
                 liz=xbmcgui.ListItem(title)
-                liz.setInfo( type="Video", infoLabels={ "Title": title } )
 
                 # check if a video url is provided
                 if 'fields' in item:
+                    description = title
+                    if 'description' in item['fields']:
+                        description = item['fields']['description']
+                    liz.setInfo( type="Video", infoLabels={ "Title": title, "plot": description } )
                     video_url = None
                     if 'playbackScenarios' in item['fields']:
                         for playback in item['fields']['playbackScenarios']:
@@ -256,6 +321,7 @@ def featured_videos(featured_video=None):
                         isFolder=False
                 # if no video url is provided, we assume it is just another list
                 else:
+                    liz.setInfo( type="Video", infoLabels={ "Title": title } )
                     list_url = item['url']
                     xbmc.log('list url : ' + list_url)
                     if list_url == "":
@@ -366,168 +432,276 @@ def create_big_inning_listitem(game_day):
         pass
 
 
-def stream_select(game_pk, spoiler='True', from_context_menu=False):
+def stream_select(game_pk, spoiler, suspended, start_inning, description, name, icon, fanart, from_context_menu=False, autoplay=False):
+    # fetch the epg content using the game_pk
     url = API_URL + '/api/v1/game/' + game_pk + '/content'
     headers = {
         'User-Agent': UA_ANDROID
     }
     r = requests.get(url, headers=headers, verify=VERIFY)
     json_source = r.json()
+    # start with just video content, assumed to be at index 0
+    epg = json_source['media']['epg'][0]['items']
 
+    # define some default variables
     selected_content_id = None
+    selected_media_state = None
     stream_url = ''
-    start = '1'
+    broadcast_start_offset = '1' # offset to pass to inputstream adaptive
+    broadcast_start_timestamp = None # to pass to skip monitor
     stream_type = 'video'
-    skip_possible = False
+    skip_possible = True # to determine if possible to show skip options dialog
     skip_type = 0
-    is_live = False
-    start_inning = 0
+    is_live = False # to pass to skip monitor
+    # convert start inning values to integers
+    if start_inning == 'False':
+        start_inning = 0
+    else:
+        start_inning = int(start_inning)
     start_inning_half = 'top'
+    # define a dialog that we can use as needed
     dialog = xbmcgui.Dialog()
 
-    # if auto select stream is enabled and not bypassed with context menu item, loop through looking for favorite team's feed or home/national feed, in that order
-    if AUTO_SELECT_STREAM == 'true' and from_context_menu == False:
-        epg = json_source['media']['epg'][0]['items']
+    # auto select stream if enabled and not bypassed with context menu item and it's not an archived suspended game, or if autoplay is forced
+    if (AUTO_SELECT_STREAM == 'true' and from_context_menu is False and suspended != 'archive') or autoplay is True:
+        # loop through the streams to determine the best match
         for item in epg:
-            if item['mediaState'] != 'MEDIA_OFF':
-                if 'mediaFeedType' in item and item['mediaFeedType'] != 'IN_MARKET_HOME' and item['mediaFeedType'] != 'IN_MARKET_AWAY':
-                    if FAV_TEAM != 'None' and 'mediaFeedSubType' in item and item['mediaFeedSubType'] == getFavTeamId():
+            # ignore streams that haven't started yet, audio streams (without a mediaFeedType), and in-market streams
+            if item['mediaState'] != 'MEDIA_OFF' and 'mediaFeedType' in item and item['mediaFeedType'] != 'IN_MARKET_HOME' and item['mediaFeedType'] != 'IN_MARKET_AWAY':
+                # check if our favorite team (if defined) is associated with this stream
+                # or if no favorite team match, look for the home or national streams
+                if (FAV_TEAM != 'None' and 'mediaFeedSubType' in item and item['mediaFeedSubType'] == getFavTeamId()) or (selected_content_id is None and 'mediaFeedType' in item and (item['mediaFeedType'] == 'HOME' or item['mediaFeedType'] == 'NATIONAL' )):
+                    # prefer live streams (suspended games can have both a live and archived stream available)
+                    if item['mediaState'] == 'MEDIA_ON':
                         selected_content_id = item['contentId']
-                        break
-                    elif selected_content_id is None and 'mediaFeedType' in item and (item['mediaFeedType'] == 'HOME' or item['mediaFeedType'] == 'NATIONAL' ):
+                        selected_media_state = item['mediaState']
+                        # once we've found a fav team live stream, we don't need to search any further
+                        if FAV_TEAM != 'None' and 'mediaFeedSubType' in item and item['mediaFeedSubType'] == getFavTeamId():
+                            break
+                    # fall back to the first available archive stream, but keep search in case there is a live stream (suspended)
+                    elif item['mediaState'] == 'MEDIA_ARCHIVE' and selected_content_id is None:
                         selected_content_id = item['contentId']
+                        selected_media_state = item['mediaState']
 
-    # fallback to manual stream selection if auto is disabled, bypassed, or didn't find anything
-    if selected_content_id is None:
+    # fallback to manual stream selection if auto selection is disabled, bypassed, or didn't find anything, and we're not looking to force autoplay
+    if selected_content_id is None and autoplay is False:
+        # default stream selection list starts with highlights option
+        stream_title = [LOCAL_STRING(30391)]
+        highlight_offset = 1
+        content_id = []
+        media_state = []
+        # if using Kodi's default resume ability, we'll omit highlights from our stream selection prompt
         if sys.argv[3] == 'resume:true':
             stream_title = []
             highlight_offset = 0
-        else:
-            stream_title = [LOCAL_STRING(30391)]
-            highlight_offset = 1
-        media_state = []
-        content_id = []
-        # combine tv and radio items
-        epg = json_source['media']['epg'][0]['items'] + json_source['media']['epg'][2]['items']
+
+        # define some more variables used to handle suspended games
+        airings = None
+        game_date = None
+
+        # if not live, if suspended, or if live and not resuming, add audio streams to the video streams
+        if epg[0]['mediaState'] != "MEDIA_ON" or suspended != 'False' or (epg[0]['mediaState'] == "MEDIA_ON" and sys.argv[3] != 'resume:true'):
+            epg += json_source['media']['epg'][2]['items']
+
         for item in epg:
-            xbmc.log(str(item))
+            #xbmc.log(str(item))
+            # only display if the stream is available (either live or archive)
             if item['mediaState'] != 'MEDIA_OFF':
-                # tv and radio items use different variables for home/away
+                # video and audio streams use different fields to indicate home/away
                 if 'mediaFeedType' in item:
                     media_feed_type = str(item['mediaFeedType'])
                 else:
                     media_feed_type = str(item['type'])
+
+                # ignore in-market streams if necessary
                 if IN_MARKET != 'Hide' or (media_feed_type != 'IN_MARKET_HOME' and media_feed_type != 'IN_MARKET_AWAY'):
                     title = media_feed_type.title()
                     title = title.replace('_', ' ')
+
+                    # add TV to video stream
                     if 'mediaFeedType' in item:
                         title += LOCAL_STRING(30392)
+                    # add language to audio stream
                     else:
                         if item['language'] == 'en':
                             title += LOCAL_STRING(30394)
                         elif item['language'] == 'es':
                             title += LOCAL_STRING(30395)
                         title += LOCAL_STRING(30393)
-                    if 'mediaFeedType' in item and ('HOME' in title.upper() or 'NATIONAL' in title.upper()):
-                        media_state.insert(0, item['mediaState'])
-                        content_id.insert(0, item['contentId'])
-                        stream_title.insert(highlight_offset, title + " (" + item['callLetters'] + ")")
-                    else:
-                        media_state.append(item['mediaState'])
-                        content_id.append(item['contentId'])
-                        stream_title.append(title + " (" + item['callLetters'] + ")")
+                    title = title + " (" + item['callLetters'] + ")"
 
-        # All past games should have highlights
+                    # modify stream title based on suspension status, if necessary
+                    if suspended != 'False':
+                        suspended_label = 'partial'
+                        try:
+                            # if the game hasn't finished, we can simply tell the status from the mediaState
+                            if suspended == 'live' and item['mediaState'] == 'MEDIA_ARCHIVE':
+                                suspended_label = 'Suspended'
+                            elif suspended == 'live':
+                                suspended_label = 'Resumed'
+                            # otherwise if the game is complete, we need to check the airings data
+                            else:
+                                if game_date is None and 'gameDate' in item:
+                                    game_date = item['gameDate']
+                                if airings is None and game_date is not None:
+                                    airings = get_airings_data(game_pk=game_pk)
+                                if game_date is not None and airings is not None and 'data' in airings and 'Airings' in airings['data']:
+                                    for airing in airings['data']['Airings']:
+                                        if airing['contentId'] == item['contentId']:
+                                            # compare the start date of the airing with the provided game_date
+                                            start_date = get_eastern_game_date(parse(airing['startDate']))
+                                            # same day means it is resumed
+                                            if game_date == start_date:
+                                                suspended_label = 'Resumed'
+                                            # different day means it was suspended
+                                            else:
+                                                suspended_label = 'Suspended'
+                                            break
+                        except:
+                            pass
+                        title += ' (' + suspended_label + ')'
+
+                    # insert home/national video streams at the top of the list
+                    if 'mediaFeedType' in item and ('HOME' in title.upper() or 'NATIONAL' in title.upper()):
+                        content_id.insert(0, item['contentId'])
+                        media_state.insert(0, item['mediaState'])
+                        stream_title.insert(highlight_offset, title)
+                    # otherwise append other streams to end of list
+                    else:
+                        content_id.append(item['contentId'])
+                        media_state.append(item['mediaState'])
+                        stream_title.append(title)
+
+        # if we didn't find any streams, display an error and exit
         if len(stream_title) == 0:
-            dialog = xbmcgui.Dialog()
             dialog.notification(LOCAL_STRING(30383), LOCAL_STRING(30384), ICON, 5000, False)
             xbmcplugin.setResolvedUrl(addon_handle, False, xbmcgui.ListItem())
             sys.exit()
 
+        # stream selection dialog
         n = dialog.select(LOCAL_STRING(30390), stream_title)
-        if n == -1:
-            sys.exit()
+        # highlights selection will go to that function and stop processing here
+        if n == 0 and highlight_offset == 1:
+            highlight_select_stream(json_source['highlights']['highlights']['items'], from_context_menu=from_context_menu)
+        # stream selection
         elif n > -1 and stream_title[n] != LOCAL_STRING(30391):
-            # check if selected stream is a radio stream, which can't play with inputstream adaptive
+            # check if selected stream is a radio stream
             if LOCAL_STRING(30393) in stream_title[n]:
                 stream_type = 'audio'
             selected_content_id = content_id[n-highlight_offset]
+            selected_media_state = media_state[n-highlight_offset]
+        # cancel will exit
+        elif n == -1:
+            sys.exit()
 
+    # only proceed with start/skip dialogs if we have a content_id, either from auto-selection or the stream selection dialog
     if selected_content_id is not None:
+        # need to log in to get the stream url and headers
         account = Account()
-        stream_url, headers, broadcast_start = account.get_stream(selected_content_id)
-        if sys.argv[3] == 'resume:true':
-            spoiler = "True"
-            if stream_type == 'video':
-                skip_possible = True
-        elif epg[0]['mediaState'] == "MEDIA_ON" and CATCH_UP == 'true' and stream_type == 'video' and from_context_menu == False:
+        # get the broadcast start offset and timestamp too, to know where to start playback and calculate skip markers, if necessary
+        stream_url, headers, broadcast_start_offset, broadcast_start_timestamp = account.get_stream(selected_content_id)
+
+        if selected_media_state == 'MEDIA_ON':
             is_live = True
-            start_options = [LOCAL_STRING(30397), LOCAL_STRING(30398), LOCAL_STRING(30399)]
-            # add inning start options
-            for x in range(1, 12):
-                start_options.append(LOCAL_STRING(30409) + ' ' + LOCAL_STRING(30407) + ' ' + str(x))
-                start_options.append(LOCAL_STRING(30410) + ' ' + LOCAL_STRING(30407) + ' ' + str(x))
-            p = dialog.select(LOCAL_STRING(30396), start_options)
-            if p == 0:
-                listitem = stream_to_listitem(stream_url, headers)
-                highlight_select_stream(json_source['highlights']['highlights']['items'], listitem)
-                sys.exit()
-            elif p == 1 or p > 2:
-                spoiler = "False"
-                start = broadcast_start
-                skip_possible = True
-                if p > 2:
-                    p = p - 2
-                    start_inning = int(round(((p+0.5) / 2), 0))
-                    if (p % 2) == 0 and ((p+1) % 2) == 1:
-                        start_inning_half = 'bottom'
-            elif p == 2:
-                spoiler = "True"
-            elif p == -1:
-                sys.exit()
-        # don't offer to start live radio streams from beginning
-        elif epg[0]['mediaState'] == "MEDIA_ON" and CATCH_UP == 'true' and stream_type == 'audio' and from_context_menu == False:
-            p = dialog.select(LOCAL_STRING(30396), [LOCAL_STRING(30397), LOCAL_STRING(30399)])
-            if p == 0:
-                listitem = stream_to_listitem(stream_url, headers, 'True', '1', 'audio')
-                highlight_select_stream(json_source['highlights']['highlights']['items'], listitem)
-                sys.exit()
-            elif p == -1:
-                sys.exit()
-        elif stream_type == 'video' and from_context_menu == False:
-            skip_possible = True
-            # For archive games, offer to start at inning if catch up is enabled
-            if CATCH_UP == 'true':
-                start_options = [LOCAL_STRING(30398)]
+
+        if stream_type == 'audio':
+            skip_possible = False
+
+        # only show the start point dialog if not using Kodi's default resume ability, the "ask to catch up" option is enabled, no start inning is specified, and we're not looking to autoplay
+        if sys.argv[3] != 'resume:true' and CATCH_UP == 'true' and start_inning == 0 and autoplay is False:
+
+            # for live video streams
+            if selected_media_state == "MEDIA_ON" and stream_type == 'video':
+                # begin with catch up, beginning, and live as start point options
+                start_options = [LOCAL_STRING(30397), LOCAL_STRING(30398), LOCAL_STRING(30399)]
                 # add inning start options
-                for x in range(1, 12):
-                    start_options.append(LOCAL_STRING(30409) + ' ' + LOCAL_STRING(30407) + ' ' + str(x))
-                    start_options.append(LOCAL_STRING(30410) + ' ' + LOCAL_STRING(30407) + ' ' + str(x))
+                start_options += get_inning_start_options()
+
+                # start point selection dialog
                 p = dialog.select(LOCAL_STRING(30396), start_options)
-                if p > 0:
-                    start_inning = int(round(((p+0.5) / 2), 0))
-                    if (p % 2) == 0 and ((p+1) % 2) == 1:
-                        start_inning_half = 'bottom'
+                # catch up
+                if p == 0:
+                    # create an item for the video stream
+                    listitem = stream_to_listitem(stream_url, headers, description, icon, fanart)
+                    # pass along the highlights and the video stream item to play as a playlist and stop processing here
+                    highlight_select_stream(json_source['highlights']['highlights']['items'], catchup=listitem)
+                    sys.exit()
+                # beginning or inning
+                elif p == 1 or p > 2:
+                    # inning top/bottom calculation
+                    if p > 2:
+                        p = p - 2
+                        start_inning, start_inning_half = calculate_inning_from_index(p)
+                # live
+                elif p == 2:
+                    broadcast_start_offset = '-1'
+                    skip_possible = False
+                # cancel will exit
                 elif p == -1:
                     sys.exit()
 
-    if skip_possible == True and ASK_TO_SKIP == 'true' and from_context_menu == False:
-        skip_type = dialog.select(LOCAL_STRING(30403), [LOCAL_STRING(30404), LOCAL_STRING(30408), LOCAL_STRING(30405), LOCAL_STRING(30406)])
-        if skip_type == -1:
+            # for live audio streams
+            elif selected_media_state == "MEDIA_ON" and stream_type == 'audio':
+                # start point selection dialog, with only catch up and live
+                # omitting the beginning and inning start options (they don't work for live audio)
+                p = dialog.select(LOCAL_STRING(30396), [LOCAL_STRING(30397), LOCAL_STRING(30399)])
+                # catch up
+                if p == 0:
+                    # create an item for the audio stream
+                    listitem = stream_to_listitem(stream_url, headers, description, icon, fanart, stream_type='audio')
+                    # pass along the highlights and the audio stream item to play as a playlist and stop processing here
+                    highlight_select_stream(json_source['highlights']['highlights']['items'], catchup=listitem)
+                    sys.exit()
+                # cancel will exit
+                elif p == -1:
+                    sys.exit()
+
+            # for archive video streams
+            elif stream_type == 'video':
+                # beginning is initial start point option
+                start_options = [LOCAL_STRING(30398)]
+                # add inning start options
+                start_options += get_inning_start_options()
+                # start point selection dialog
+                p = dialog.select(LOCAL_STRING(30396), start_options)
+                # inning
+                if p > 0:
+                    start_inning, start_inning_half = calculate_inning_from_index(p)
+                # cancel will exit
+                elif p == -1:
+                    sys.exit()
+
+        # show automatic skip dialog, if possible, enabled, and we're not looking to autoplay
+        if skip_possible is True and ASK_TO_SKIP == 'true' and autoplay is False:
+            # automatic skip dialog with options to skip nothing, breaks, breaks + idle time, breaks + idle time + non-action pitches
+            skip_type = dialog.select(LOCAL_STRING(30403), [LOCAL_STRING(30404), LOCAL_STRING(30408), LOCAL_STRING(30405), LOCAL_STRING(30406)])
+            # cancel will exit
+            if skip_type == -1:
+                sys.exit()
+
+        # if autoplay, join live
+        if autoplay is True:
+            broadcast_start_offset = '-1'
+        # if not live and no spoilers and not audio, generate a random number of segments to pad at end of proxy stream url
+        elif is_live is False and spoiler == 'False' and stream_type != 'audio':
+            pad = random.randint(720, 2160)
+            headers += '&pad=' + str(pad)
+            stream_url = 'http://127.0.0.1:43670/' + stream_url
+
+        # valid stream url
+        if '.m3u8' in stream_url:
+            play_stream(stream_url, headers, description, title=name, icon=icon, fanart=fanart, start=broadcast_start_offset, stream_type=stream_type)
+            # start the skip monitor if a skip type or start inning has been requested and we have a broadcast start timestamp
+            if (skip_type > 0 or start_inning > 0) and broadcast_start_timestamp is not None:
+                mlbmonitor = MLBMonitor()
+                mlbmonitor.skip_monitor(skip_type, game_pk, broadcast_start_timestamp, is_live, start_inning, start_inning_half)
+        # otherwise exit
+        else:
             sys.exit()
-
-    if '.m3u8' in stream_url:
-        play_stream(stream_url, headers, spoiler, start, stream_type, skip_type, selected_content_id, game_pk, is_live, start_inning, start_inning_half)
-
-    elif stream_title[n] == LOCAL_STRING(30391):
-        highlight_select_stream(json_source['highlights']['highlights']['items'], None, from_context_menu)
-
-    else:
-        sys.exit()
 
 
 # select a stream for a featured video
-def featured_stream_select(featured_video, name):
+def featured_stream_select(featured_video, name, description):
     xbmc.log('video select')
     account = Account()
     video_url = None
@@ -603,12 +777,12 @@ def featured_stream_select(featured_video, name):
         if name.startswith('LIVE') and 'Big Inning' in name and KODI_VERSION < 19 and not xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)'):
             dialog = xbmcgui.Dialog()
             dialog.ok(LOCAL_STRING(30370), LOCAL_STRING(30369))
-        play_stream(video_stream_url, headers)
+        play_stream(video_stream_url, headers, description, title=name, start='-1')
     else:
         xbmc.log('unable to find stream for featured video')
 
 
-def list_highlights(game_pk):
+def list_highlights(game_pk, icon, fanart):
     url = API_URL + '/api/v1/game/' + game_pk + '/content'
     headers = {
         'User-Agent': UA_ANDROID
@@ -627,9 +801,12 @@ def list_highlights(game_pk):
 
         # play all
         liz=xbmcgui.ListItem(LOCAL_STRING(30411))
-        liz.setInfo( type="Video", infoLabels={ "Title": LOCAL_STRING(30411) } )
+        liz.setInfo( type="Video", infoLabels={ "Title": LOCAL_STRING(30411), "plot": LOCAL_STRING(30411) } )
+        if icon is None: icon = ICON
+        if fanart is None: fanart = FANART
+        liz.setArt({'icon': icon, 'thumb': icon, 'fanart': fanart})
         liz.setProperty("IsPlayable", "true")
-        u=sys.argv[0]+"?mode="+str(107)+"&game_pk="+urllib.quote_plus(game_pk)
+        u=sys.argv[0]+"?mode="+str(107)+"&game_pk="+urllib.quote_plus(str(game_pk))+"&fanart="+urllib.quote_plus(fanart)
         isFolder=False
 
         xbmcplugin.addDirectoryItem(handle=addon_handle,url=u,listitem=liz,isFolder=isFolder)
@@ -637,17 +814,17 @@ def list_highlights(game_pk):
 
         for clip in highlights:
             liz=xbmcgui.ListItem(clip['title'])
-            liz.setInfo( type="Video", infoLabels={ "Title": clip['title'] } )
-            liz.setArt({'icon': clip['icon'], 'thumb': clip['icon']})
+            liz.setInfo( type="Video", infoLabels={ "Title": clip['title'], "plot": clip['description'] } )
+            liz.setArt({'icon': icon, 'thumb': clip['icon'], 'fanart': fanart})
             liz.setProperty("IsPlayable", "true")
-            u=sys.argv[0]+"?mode="+str(301)+"&featured_video="+urllib.quote_plus(clip['url'])+"&name="+urllib.quote_plus(clip['title'])
+            u=sys.argv[0]+"?mode="+str(301)+"&featured_video="+urllib.quote_plus(clip['url'])+"&name="+urllib.quote_plus(clip['title'])+"&description="+urllib.quote_plus(clip['description'])
             isFolder=False
 
             xbmcplugin.addDirectoryItem(handle=addon_handle,url=u,listitem=liz,isFolder=isFolder)
             xbmcplugin.setContent(addon_handle, 'episodes')
 
 
-def play_all_highlights_for_game(game_pk):
+def play_all_highlights_for_game(game_pk, fanart):
     url = API_URL + '/api/v1/game/' + game_pk + '/content'
     headers = {
         'User-Agent': UA_ANDROID
@@ -662,8 +839,8 @@ def play_all_highlights_for_game(game_pk):
 
         for clip in highlights:
             listitem = xbmcgui.ListItem(clip['url'])
-            listitem.setArt({'icon': clip['icon'], 'thumb': clip['icon'], 'fanart': FANART})
-            listitem.setInfo(type="Video", infoLabels={"Title": clip['title']})
+            listitem.setArt({'icon': clip['icon'], 'thumb': clip['icon'], 'fanart': fanart})
+            listitem.setInfo(type="Video", infoLabels={"Title": clip['title'], "plot": clip['description']})
             playlist.add(clip['url'], listitem)
 
         xbmcplugin.setResolvedUrl(handle=addon_handle, succeeded=True, listitem=playlist[0])
@@ -680,13 +857,16 @@ def highlight_select_stream(json_source, catchup=None, from_context_menu=False):
 
     highlight_name = []
     highlight_url = []
-    if from_context_menu == False:
+    highlight_blurb = []
+    if from_context_menu is False:
         highlight_name.append(LOCAL_STRING(30411))
-        highlight_url.append('junk')
+        highlight_url.append('blank')
+        highlight_blurb.append(LOCAL_STRING(30411))
 
     for clip in highlights:
         highlight_name.append(clip['title'])
         highlight_url.append(clip['url'])
+        highlight_blurb.append(clip['description'])
 
     if catchup is None:
         dialog = xbmcgui.Dialog()
@@ -695,7 +875,8 @@ def highlight_select_stream(json_source, catchup=None, from_context_menu=False):
         a = 0
 
     if a > 0:
-        play_stream(highlight_url[a], '')
+        headers = 'User-Agent=' + UA_PC
+        play_stream(highlight_url[a], headers, highlight_blurb[a], highlight_name[a])
     elif a == 0:
         playlist = xbmc.PlayList(xbmc.PLAYLIST_VIDEO)
         playlist.clear()
@@ -703,7 +884,7 @@ def highlight_select_stream(json_source, catchup=None, from_context_menu=False):
         for clip in highlights:
             listitem = xbmcgui.ListItem(clip['url'])
             listitem.setArt({'icon': clip['icon'], 'thumb': clip['icon'], 'fanart': FANART})
-            listitem.setInfo(type="Video", infoLabels={"Title": clip['title']})
+            listitem.setInfo(type="Video", infoLabels={"Title": clip['title'], "plot": clip["blurb"]})
             playlist.add(clip['url'], listitem)
 
         if catchup is not None:
@@ -714,12 +895,9 @@ def highlight_select_stream(json_source, catchup=None, from_context_menu=False):
         sys.exit()
 
 
-def play_stream(stream_url, headers, spoiler='True', start='1', stream_type='video', skip_type=0, content_id=None, game_pk=None, is_live=False, start_inning=0, start_inning_half='top'):
-    listitem = stream_to_listitem(stream_url, headers, spoiler, start, stream_type)
+def play_stream(stream_url, headers, description, title, icon=None, fanart=None, start='1', stream_type='video'):
+    listitem = stream_to_listitem(stream_url, headers, description, title, icon, fanart, start=start, stream_type=stream_type)
     xbmcplugin.setResolvedUrl(handle=addon_handle, succeeded=True, listitem=listitem)
-    if skip_type > 0 or start_inning > 0:
-        mlbmonitor = MLBMonitor()
-        mlbmonitor.skip_monitor(skip_type, content_id, game_pk, is_live, start_inning, start_inning_half)
 
 
 def get_highlights(items):
@@ -732,7 +910,8 @@ def get_highlights(items):
                 break
         headline = item['headline']
         icon = item['image']['cuts'][0]['src']
-        highlights.append({'url': clip_url, 'title': headline, 'icon': icon})
+        description = item['blurb']
+        highlights.append({'url': clip_url, 'title': headline, 'icon': icon, 'description': description})
 
     return highlights
 
@@ -783,3 +962,56 @@ def playAllHighlights(stream_date):
 
     xbmc.Player().play(playlist)
 
+
+def live_fav_game():
+    game_day = localToEastern()
+
+    auto_play_game_date = str(settings.getSetting(id='auto_play_game_date'))
+
+    game_pk = None
+
+    # don't check if we've already flagged today's fav games as complete
+    if auto_play_game_date != game_day:
+        # don't check more often than 5 minute intervals
+        auto_play_game_checked = str(settings.getSetting(id='auto_play_game_checked'))
+        now = datetime.now()
+        if auto_play_game_checked == '' or (parse(auto_play_game_checked) + timedelta(minutes=5)) < now:
+            settings.setSetting(id='auto_play_game_checked', value=str(now))
+
+            url = API_URL + '/api/v1/schedule'
+            url += '?hydrate=game(content(media(epg)))'
+            url += '&sportId=1,51'
+            url += '&teamId=' + getFavTeamId()
+            url += '&date=' + game_day
+
+            headers = {
+                'User-Agent': UA_ANDROID
+            }
+            r = requests.get(url,headers=headers, verify=VERIFY)
+            json_source = r.json()
+
+            upcoming_game = False
+
+            if 'dates' in json_source and len(json_source['dates']) > 0 and 'games' in json_source['dates'][0]:
+                for game in json_source['dates'][0]['games']:
+                    try:
+                        # only check games that aren't final
+                        if game['status']['abstractGameState'] != 'Final':
+                            if 'content' in game and 'media' in game['content'] and 'epg' in game['content']['media'] and len(game['content']['media']['epg']) > 0 and 'items' in game['content']['media']['epg'][0]:
+                                for epg in game['content']['media']['epg'][0]['items']:
+                                    # if media is off, assume it is still upcoming
+                                    if epg['mediaState'] == 'MEDIA_OFF':
+                                        upcoming_game = True
+                                    # if media is on, that means it is live
+                                    elif game_pk is None and epg['mediaState'] == 'MEDIA_ON':
+                                        game_pk = str(game['gamePk'])
+                                        xbmc.log('Found live fav game ' + game_pk)
+                    except:
+                        pass
+
+            # set the date setting if there are no more upcoming fav games today
+            if upcoming_game is False:
+                xbmc.log('No more upcoming fav games today')
+                settings.setSetting(id='auto_play_game_date', value=game_day)
+
+    return game_pk

--- a/resources/lib/mlbmonitor.py
+++ b/resources/lib/mlbmonitor.py
@@ -20,43 +20,43 @@ class MLBMonitor(xbmc.Monitor):
             xbmc.log("MLB Monitor from " + self.mlb_monitor_started + " closing due to another monitor starting on " + new_mlb_monitor_started)
             self.mlb_monitor_started = ''
 
-    def skip_monitor(self, skip_type, content_id, game_pk, is_live, start_inning, start_inning_half):
-        xbmc.log("Skip monitor for " + content_id + " starting")
+    def skip_monitor(self, skip_type, game_pk, broadcast_start_timestamp, is_live, start_inning, start_inning_half):
+        xbmc.log("Skip monitor for " + game_pk + " starting")
 
         self.mlb_monitor_started = str(datetime.now())
         settings.setSetting(id='mlb_monitor_started', value=self.mlb_monitor_started)
-        xbmc.log("Skip monitor for " + content_id + " started at " + self.mlb_monitor_started)
+        xbmc.log("Skip monitor for " + game_pk + " started at " + self.mlb_monitor_started)
 
         # initialize player to monitor play time
         player = xbmc.Player()
         last_time = None
 
         # fetch skip markers
-        skip_markers = self.get_skip_markers(skip_type, content_id, game_pk, 0, start_inning, start_inning_half)
-        xbmc.log('Skip monitor for ' + content_id + ' skip markers : ' + str(skip_markers))
+        skip_markers = self.get_skip_markers(skip_type, game_pk, broadcast_start_timestamp, 0, start_inning, start_inning_half)
+        xbmc.log('Skip monitor for ' + game_pk + ' skip markers : ' + str(skip_markers))
 
         while not self.monitor.abortRequested():
             if self.monitor.waitForAbort(1):
-                xbmc.log("Skip monitor for " + content_id + " aborting")
+                xbmc.log("Skip monitor for " + game_pk + " aborting")
                 break
             elif len(skip_markers) == 0:
-                xbmc.log("Skip monitor for " + content_id + " closing due to no more skip markers")
+                xbmc.log("Skip monitor for " + game_pk + " closing due to no more skip markers")
                 break
             elif self.stream_started == True and not xbmc.getCondVisibility("Player.HasMedia"):
-                xbmc.log("Skip monitor for " + content_id + " closing due to stream stopped")
+                xbmc.log("Skip monitor for " + game_pk + " closing due to stream stopped")
                 break
             elif self.mlb_monitor_started == '':
-                xbmc.log("Skip monitor for " + content_id + " closing due to reset")
+                xbmc.log("Skip monitor for " + game_pk + " closing due to reset")
                 break
             elif xbmc.getCondVisibility("Player.HasMedia"):
                 if self.stream_started == False:
-                    xbmc.log("Skip monitor for " + content_id + " detected stream start")
+                    xbmc.log("Skip monitor for " + game_pk + " detected stream start")
                     self.stream_started = True
                     # just for fun, we can log our stream duration, to compare it against skip time detected
                     if start_inning == 0:
                         try:
                             total_stream_time = player.getTotalTime()
-                            xbmc.log('Skip monitor for ' + content_id + ' total stream time ' + str(timedelta(seconds=total_stream_time)))
+                            xbmc.log('Skip monitor for ' + game_pk + ' total stream time ' + str(timedelta(seconds=total_stream_time)))
                         except:
                             pass
                 current_time = player.getTime()
@@ -65,11 +65,11 @@ class MLBMonitor(xbmc.Monitor):
                     last_time = current_time
                     # remove any past skip markers so user can seek backward freely
                     while len(skip_markers) > 0 and current_time > skip_markers[0][1]:
-                        xbmc.log("Skip monitor for " + content_id + " removed skip marker at " + str(skip_markers[0][1]) + ", before current time " + str(current_time))
+                        xbmc.log("Skip monitor for " + game_pk + " removed skip marker at " + str(skip_markers[0][1]) + ", before current time " + str(current_time))
                         skip_markers.pop(0)
                     # seek to end of break if we fall within skip marker range, then remove marker so user can seek backward freely
                     if len(skip_markers) > 0 and current_time >= skip_markers[0][0] and current_time < skip_markers[0][1]:
-                        xbmc.log("Skip monitor for " + content_id + " processed skip marker at " + str(skip_markers[0][1]))
+                        xbmc.log("Skip monitor for " + game_pk + " processed skip marker at " + str(skip_markers[0][1]))
                         player.seekTime(skip_markers[0][1])
                         skip_markers.pop(0)
                         # since we just processed a skip marker, we can delay further processing a little bit
@@ -78,18 +78,18 @@ class MLBMonitor(xbmc.Monitor):
                     if len(skip_markers) == 0 and is_live == True and skip_type > 0:
                         # refresh current time, and look ahead slightly
                         current_time = player.getTime() + 10
-                        xbmc.log('Skip monitor for ' + content_id + ' refreshing skip markers from ' + str(current_time))
-                        skip_markers = self.get_skip_markers(skip_type, content_id, game_pk, current_time)
-                        xbmc.log('Skip monitor for ' + content_id + ' refreshed skip markers : ' + str(skip_markers))
+                        xbmc.log('Skip monitor for ' + game_pk + ' refreshing skip markers from ' + str(current_time))
+                        skip_markers = self.get_skip_markers(skip_type, game_pk, broadcast_start_timestamp, current_time)
+                        xbmc.log('Skip monitor for ' + game_pk + ' refreshed skip markers : ' + str(skip_markers))
             else:
                 if self.stream_started == False:
-                    xbmc.log("Skip monitor for " + content_id + " waiting for stream to start")
+                    xbmc.log("Skip monitor for " + game_pk + " waiting for stream to start")
                     self.stream_start_tries -= 1
                     if self.stream_start_tries < 1:
-                        xbmc.log("Skip monitor for " + content_id + " closing due to stream not starting")
+                        xbmc.log("Skip monitor for " + game_pk + " closing due to stream not starting")
                         break
 
-        xbmc.log("Skip monitor for " + content_id + " closed")
+        xbmc.log("Skip monitor for " + game_pk + " closed")
 
 
     # get the gameday data, which contains the event timestamps
@@ -109,148 +109,94 @@ class MLBMonitor(xbmc.Monitor):
 
 
     # calculate skip markers from gameday events
-    def get_skip_markers(self, skip_type, content_id, game_pk, current_time=0, start_inning=0, start_inning_half='top'):
-        xbmc.log('Skip monitor for ' + content_id + ' getting skip markers for skip type ' + str(skip_type))
+    def get_skip_markers(self, skip_type, game_pk, broadcast_start_timestamp, current_time=0, start_inning=0, start_inning_half='top'):
+        xbmc.log('Skip monitor for ' + game_pk + ' getting skip markers for skip type ' + str(skip_type))
         if current_time > 0:
-            xbmc.log('Skip monitor for ' + content_id + ' searching beyond ' + str(current_time))
+            xbmc.log('Skip monitor for ' + game_pk + ' searching beyond ' + str(current_time))
 
         # initialize our list of skip times
         skip_markers = []
 
-        # first get the broadcast start time, so we can subtract it from the event timestamps
-        self.broadcast_start_timestamp = self.get_broadcast_start(content_id)
-        if self.broadcast_start_timestamp is None:
-            xbmc.log('Skip monitor for ' + content_id + ' failed to find broadcast start timestamp')
-            self.mlb_monitor_started = ''
-        else:
-            json_source = self.get_gameday_data(game_pk)
+        json_source = self.get_gameday_data(game_pk)
 
-            # calculate total skip time (for fun)
-            total_skip_time = 0
+        # calculate total skip time (for fun)
+        total_skip_time = 0
 
-            # make sure we have play data
-            if 'liveData' in json_source and 'plays' in json_source['liveData'] and 'allPlays' in json_source['liveData']['plays']:
-                # assume the game starts in a break
-                break_start = 0
+        # make sure we have play data
+        if 'liveData' in json_source and 'plays' in json_source['liveData'] and 'allPlays' in json_source['liveData']['plays']:
+            # assume the game starts in a break
+            break_start = 0
 
-                # keep track of inning, if skipping inning breaks only
-                previous_inning = 0
-                previous_inning_half = None
+            # keep track of inning, if skipping inning breaks only
+            previous_inning = 0
+            previous_inning_half = None
 
-                # make sure start inning is valid
-                if start_inning > 0:
-                    last_play_index = len(json_source['liveData']['plays']['allPlays']) - 1
-                    final_inning = json_source['liveData']['plays']['allPlays'][last_play_index]['about']['inning']
-                    if start_inning >= final_inning:
-                        if start_inning > final_inning:
-                            start_inning = final_inning
-                        final_inning_half = json_source['liveData']['plays']['allPlays'][last_play_index]['about']['halfInning']
-                        if start_inning_half == 'bottom' and final_inning_half == 'top':
-                            start_inning_half = final_inning_half
+            # make sure start inning is valid
+            if start_inning > 0:
+                last_play_index = len(json_source['liveData']['plays']['allPlays']) - 1
+                final_inning = json_source['liveData']['plays']['allPlays'][last_play_index]['about']['inning']
+                if start_inning >= final_inning:
+                    if start_inning > final_inning:
+                        start_inning = final_inning
+                    final_inning_half = json_source['liveData']['plays']['allPlays'][last_play_index]['about']['halfInning']
+                    if start_inning_half == 'bottom' and final_inning_half == 'top':
+                        start_inning_half = final_inning_half
 
-                # loop through all plays
-                for play in json_source['liveData']['plays']['allPlays']:
-                    # exit loop after found inning, if not skipping any breaks
-                    if skip_type == 0 and len(skip_markers) == 1:
-                        break
-                    current_inning = play['about']['inning']
-                    current_inning_half = play['about']['halfInning']
-                    # make sure we're past our start inning
-                    if current_inning > start_inning or (current_inning == start_inning and (current_inning_half == start_inning_half or current_inning_half == 'bottom')):
-                        # loop through events within each play
-                        for index, playEvent in enumerate(play['playEvents']):
-                            # always exclude break types
-                            if 'event' in playEvent['details'] and playEvent['details']['event'] in BREAK_TYPES:
-                                # if we're in the process of skipping inning breaks, treat the first break type we find as another inning break
-                                if skip_type == 1 and previous_inning > 0:
-                                    break_start = (parse(playEvent['startTime']) - self.broadcast_start_timestamp).total_seconds() + EVENT_END_PADDING
-                                    previous_inning = 0
-                                continue
-                            else:
-                                action_index = None
-                                # skip type 1 (breaks) and 2 (idle time) will look at all plays with an endTime
-                                if skip_type <= 2 and 'endTime' in playEvent:
-                                    action_index = index
-                                elif skip_type == 3:
-                                    # skip type 3 excludes non-action pitches (events that aren't last in the at-bat and don't fall under action types)
-                                    if index < (len(play['playEvents'])-1) and ('details' not in playEvent or 'event' not in playEvent['details'] or not any(substring in playEvent['details']['event'] for substring in ACTION_TYPES)):
-                                        continue
-                                    else:
-                                        # if the action is associated with another play or the event doesn't have an end time, use the previous event instead
-                                        if ('actionPlayId' in playEvent or 'endTime' not in playEvent) and index > 0:
-                                            action_index = index - 1
-                                        else:
-                                            action_index = index
-                                if action_index is None:
+            # loop through all plays
+            for play in json_source['liveData']['plays']['allPlays']:
+                # exit loop after found inning, if not skipping any breaks
+                if skip_type == 0 and len(skip_markers) == 1:
+                    break
+                current_inning = play['about']['inning']
+                current_inning_half = play['about']['halfInning']
+                # make sure we're past our start inning
+                if current_inning > start_inning or (current_inning == start_inning and (current_inning_half == start_inning_half or current_inning_half == 'bottom')):
+                    # loop through events within each play
+                    for index, playEvent in enumerate(play['playEvents']):
+                        # always exclude break types
+                        if 'event' in playEvent['details'] and playEvent['details']['event'] in BREAK_TYPES:
+                            # if we're in the process of skipping inning breaks, treat the first break type we find as another inning break
+                            if skip_type == 1 and previous_inning > 0:
+                                break_start = (parse(playEvent['startTime']) - broadcast_start_timestamp).total_seconds() + EVENT_END_PADDING
+                                previous_inning = 0
+                            continue
+                        else:
+                            action_index = None
+                            # skip type 1 (breaks) and 2 (idle time) will look at all plays with an endTime
+                            if skip_type <= 2 and 'endTime' in playEvent:
+                                action_index = index
+                            elif skip_type == 3:
+                                # skip type 3 excludes non-action pitches (events that aren't last in the at-bat and don't fall under action types)
+                                if index < (len(play['playEvents'])-1) and ('details' not in playEvent or 'event' not in playEvent['details'] or not any(substring in playEvent['details']['event'] for substring in ACTION_TYPES)):
                                     continue
                                 else:
-                                    break_end = (parse(play['playEvents'][action_index]['startTime']) - self.broadcast_start_timestamp).total_seconds() + EVENT_START_PADDING
-                                    # if the break end should be greater than the current playback time
-                                    # and the break duration should be greater than than our specified minimum
-                                    # and if skip type is not 1 (inning breaks) or the inning has changed
-                                    # then we'll add the skip marker
-                                    # otherwise we'll ignore it and move on to the next one
-                                    if break_end > current_time and (break_end - break_start) >= MINIMUM_BREAK_DURATION and (skip_type != 1 or current_inning != previous_inning or current_inning_half != previous_inning_half):
-                                        skip_markers.append([break_start, break_end])
-                                        total_skip_time += break_end - break_start
-                                        previous_inning = current_inning
-                                        previous_inning_half = current_inning_half
-                                        # exit loop after found inning, if not skipping breaks
-                                        if skip_type == 0:
-                                            break
-                                    break_start = (parse(play['playEvents'][action_index]['endTime']) - self.broadcast_start_timestamp).total_seconds() + EVENT_END_PADDING
-                                    # add extra padding for overturned review plays
-                                    if 'reviewDetails' in play and play['reviewDetails']['isOverturned'] == True:
-                                        break_start += 40
+                                    # if the action is associated with another play or the event doesn't have an end time, use the previous event instead
+                                    if ('actionPlayId' in playEvent or 'endTime' not in playEvent) and index > 0:
+                                        action_index = index - 1
+                                    else:
+                                        action_index = index
+                            if action_index is None:
+                                continue
+                            else:
+                                break_end = (parse(play['playEvents'][action_index]['startTime']) - broadcast_start_timestamp).total_seconds() + EVENT_START_PADDING
+                                # if the break end should be greater than the current playback time
+                                # and the break duration should be greater than than our specified minimum
+                                # and if skip type is not 1 (inning breaks) or the inning has changed
+                                # then we'll add the skip marker
+                                # otherwise we'll ignore it and move on to the next one
+                                if break_end > current_time and (break_end - break_start) >= MINIMUM_BREAK_DURATION and (skip_type != 1 or current_inning != previous_inning or current_inning_half != previous_inning_half):
+                                    skip_markers.append([break_start, break_end])
+                                    total_skip_time += break_end - break_start
+                                    previous_inning = current_inning
+                                    previous_inning_half = current_inning_half
+                                    # exit loop after found inning, if not skipping breaks
+                                    if skip_type == 0:
+                                        break
+                                break_start = (parse(play['playEvents'][action_index]['endTime']) - broadcast_start_timestamp).total_seconds() + EVENT_END_PADDING
+                                # add extra padding for overturned review plays
+                                if 'reviewDetails' in play and play['reviewDetails']['isOverturned'] == True:
+                                    break_start += 40
 
-            xbmc.log('Skip monitor for ' + content_id + ' found ' + str(timedelta(seconds=total_skip_time)) + ' total skip time')
+        xbmc.log('Skip monitor for ' + game_pk + ' found ' + str(timedelta(seconds=total_skip_time)) + ' total skip time')
 
         return skip_markers
-
-
-    # get the airings data, which contains the start time of the broadcast
-    def get_airings_data(self, content_id):
-        xbmc.log('Skip monitor for ' + content_id + ' getting airings data')
-        url = 'https://search-api-mlbtv.mlb.com/svc/search/v2/graphql/persisted/query/core/Airings'
-        headers = {
-            'Accept': 'application/json',
-            'X-BAMSDK-Version': '4.3',
-            'X-BAMSDK-Platform': 'macintosh',
-            'User-Agent': UA_PC,
-            'Origin': 'https://www.mlb.com',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Content-type': 'application/json'
-        }
-        data = {
-            'variables': '%7B%22contentId%22%3A%22' + content_id + '%22%7D'
-        }
-        r = requests.get(url, headers=headers, params=data, verify=self.verify)
-        json_source = r.json()
-
-        return json_source
-
-
-    # get the start time of the broadcast, to subtract from event timestamps
-    def get_broadcast_start(self, content_id):
-        xbmc.log('Skip monitor for ' + content_id + ' getting broadcast start')
-        # if we've already retrieved it, just return that value
-        if self.broadcast_start_timestamp is not None:
-            return self.broadcast_start_timestamp
-        else:
-            broadcast_start_timestamp = None
-
-            json_source = self.get_airings_data(content_id)
-
-            # make sure we have milestone data
-            if 'data' in json_source and 'Airings' in json_source['data'] and len(json_source['data']['Airings']) > 0 and 'milestones' in json_source['data']['Airings'][0]:
-                for milestone in json_source['data']['Airings'][0]['milestones']:
-                    if milestone['milestoneType'] == 'BROADCAST_START':
-                        offset_index = 1
-                        startDatetime_index = 0
-                        if milestone['milestoneTime'][0]['type'] == 'offset':
-                            offset_index = 0
-                            startDatetime_index = 1
-                        broadcast_start_timestamp = parse(milestone['milestoneTime'][startDatetime_index]['startDatetime']) - timedelta(seconds=milestone['milestoneTime'][offset_index]['start'])
-                        break
-
-            return broadcast_start_timestamp

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -21,15 +21,16 @@
     <setting id="quality" type="labelenum" label="30160" values="Best Available|Always Ask" default="Best Available" />
     <setting id="cdn" type="labelenum" label="30165" values="Akamai|Level 3|No Preference" default="No Preference"/>
     <setting id="no_spoilers" type="enum" label="30170" lvalues="30171|30172|30173|30174|30175" />
-    <setting id="fav_team" type="labelenum" label="30180" default="None" values="None|Washington Nationals|Toronto Blue Jays|Texas Rangers|Tampa Bay Rays|St. Louis Cardinals|Seattle Mariners|San Francisco Giants|San Diego Padres|Pittsburgh Pirates|Philadelphia Phillies|Oakland Athletics|New York Yankees|New York Mets|Minnesota Twins|Milwaukee Brewers|Los Angeles Dodgers|Los Angeles Angels|Kansas City Royals|Miami Marlins|Houston Astros|Detroit Tigers|Colorado Rockies|Cleveland Guardians|Cincinnati Reds|Chicago White Sox|Chicago Cubs|Boston Red Sox|Baltimore Orioles|Atlanta Braves|Arizona Diamondbacks" />
+    <setting id="fav_team" type="labelenum" label="30180" default="None" values="None|Washington Nationals|Toronto Blue Jays|Texas Rangers|Tampa Bay Rays|St. Louis Cardinals|Seattle Mariners|San Francisco Giants|San Diego Padres|Pittsburgh Pirates|Philadelphia Phillies|Oakland Athletics|New York Yankees|New York Mets|Minnesota Twins|Milwaukee Brewers|Miami Marlins|Los Angeles Dodgers|Los Angeles Angels|Kansas City Royals|Houston Astros|Detroit Tigers|Colorado Rockies|Cleveland Guardians|Cincinnati Reds|Chicago White Sox|Chicago Cubs|Boston Red Sox|Baltimore Orioles|Atlanta Braves|Arizona Diamondbacks" />
 
     <setting id="in_market" type="labelenum" label="30300" default="Show" values="Show|Hide" />
-    
+
     <setting id="team_names" type="select" label="30190" lvalues="30191|30192" default="0" />
     <setting id="time_format" type="select" label="30301" lvalues="30302|30301" default="0" />
     <setting id="auto_select_stream" type="bool" label="30307" default="false" />
     <setting id="catch_up" type="bool" label="30304" default="true" />
     <setting id="ask_to_skip" type="bool" label="30306" default="true" />
+    <setting id="auto_play_fav" type="bool" label="30412" default="false" />
     <setting id="only_free_games" type="bool" label="30305" default="false" />
 
     <setting id="old_username" type="text" label="" default="" visible="false"/>
@@ -39,6 +40,8 @@
     <setting id="big_inning_date" type="text" label="" default="" visible="false"/>
     <setting id="big_inning_schedule" type="text" label="" default="" visible="false"/>
     <setting id="mlb_monitor_started" type="text" label="" default="" visible="false"/>
+    <setting id="auto_play_game_date" type="text" label="" default="" visible="false"/>
+    <setting id="auto_play_game_checked" type="text" label="" default="" visible="false"/>
   </category>
   <!--Proxy-->
   <category label='30200'>

--- a/service.py
+++ b/service.py
@@ -1,0 +1,123 @@
+import threading
+
+import xbmc
+import requests
+
+try:
+    # Python3
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    from socketserver import ThreadingMixIn
+    from urllib.parse import urljoin
+except:
+    # Python2
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+    from SocketServer import ThreadingMixIn
+    from urlparse import urljoin
+
+HOST = '127.0.0.1'
+PORT = 43670
+PROXY_URL = 'http://' + HOST + ':' + str(PORT) + '/'
+STREAM_EXTENSION = '.m3u8'
+URI_START_DELIMETER = 'URI="'
+URI_END_DELIMETER = '"'
+KEY_TEXT = '-KEY:METHOD=AES-128'
+ENDLIST_TEXT = '#EXT-X-ENDLIST'
+REMOVE_IN_HEADERS = ['upgrade', 'host', 'accept-encoding', 'pad']
+REMOVE_OUT_HEADERS = ['date', 'server', 'transfer-encoding', 'keep-alive', 'connection', 'content-length', 'content-md5', 'access-control-allow-credentials', 'content-encoding']
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        return
+
+    def do_POST(self):
+        self.send_error(404)
+
+    def do_HEAD(self):
+        self.send_error(404)
+
+    def do_GET(self):
+        url = self.path.lstrip('/').strip('\\')
+        if not url.endswith(STREAM_EXTENSION):
+            self.send_error(404)
+
+        headers = {}
+        pad = 0
+        for key in self.headers:
+            if key.lower() not in REMOVE_IN_HEADERS:
+                headers[key] = self.headers[key]
+            elif key.lower() == 'pad':
+                pad = int(self.headers[key])
+
+        response = requests.get(url, headers=headers)
+
+        self.send_response(response.status_code)
+
+        for key in response.headers:
+            if key.lower() not in REMOVE_OUT_HEADERS:
+                if key.lower() == 'access-control-allow-origin':
+                    response.headers[key] = '*'
+                self.send_header(key, response.headers[key])
+
+        self.end_headers()
+
+        content = response.content.decode('utf8')
+
+        # change relative m3u8 urls to absolute urls by looking at each line
+        line_array = content.splitlines()
+        new_line_array = []
+        for line in line_array:
+            if line.startswith('#'):
+                # look for uri parameters within non-key "#" lines
+                if KEY_TEXT not in line and URI_START_DELIMETER in line:
+                    line_split = line.split(URI_START_DELIMETER)
+                    url_split = line_split[1].split(URI_END_DELIMETER, 1)
+                    absolute_url = urljoin(url, url_split[0])
+                    if absolute_url.endswith(STREAM_EXTENSION):
+                        absolute_url = PROXY_URL + absolute_url
+                    new_line = line_split[0] + URI_START_DELIMETER + absolute_url + URI_END_DELIMETER + url_split[1]
+                    new_line_array.append(new_line)
+                else:
+                    new_line_array.append(line)
+            elif line != '':
+                absolute_url = urljoin(url, line)
+                if absolute_url.endswith(STREAM_EXTENSION):
+                    absolute_url = PROXY_URL + absolute_url
+                new_line_array.append(absolute_url)
+
+        # pad the end of the stream by the requested number of segments
+        last_item_index = len(new_line_array)-1
+        if new_line_array[last_item_index] == ENDLIST_TEXT and int(pad) > 0:
+            new_line_array.pop()
+            last_item_index -= 1
+            url_line = None
+            extinf_line = None
+            while url_line is None or extinf_line is None:
+                if not new_line_array[last_item_index].startswith('#'):
+                    url_line = new_line_array[last_item_index]
+                elif new_line_array[last_item_index].startswith('#EXTINF:'):
+                    extinf_line = new_line_array[last_item_index]
+                last_item_index -= 1
+            for x in range(0, pad):
+                new_line_array.append(extinf_line)
+                new_line_array.append(url_line)
+            new_line_array.append(ENDLIST_TEXT)
+
+        content = "\n".join(new_line_array)
+
+        # Output the new content
+        self.wfile.write(content.encode('utf8'))
+
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+server = ThreadedHTTPServer((HOST, PORT), RequestHandler)
+server.allow_reuse_address = True
+httpd_thread = threading.Thread(target=server.serve_forever)
+httpd_thread.start()
+
+xbmc.Monitor().waitForAbort()
+
+server.shutdown()
+server.server_close()
+server.socket.close()
+httpd_thread.join()


### PR DESCRIPTION
Another update. Top features:

- No more timeline spoilers! When spoilers are hidden for an archive stream, the stream gets padded with a random amount of extra time on the end, so you don't know exactly how long the game has left to go. This is accomplished through a local proxy server in service.py based on [this example](https://github.com/matthuisman/proxy.plugin.example)

- Also added an option to autoplay live games for your favorite team when entering the addon, per [this request from the Kodi forum](https://forum.kodi.tv/showthread.php?tid=262745&pid=3096839#pid3096839). I think this renders the other pull request obsolete: https://github.com/eracknaphobia/plugin.video.mlbtv/pull/43

Other changes:
- a "See scores at inning" option in the main menu -- so you can look at all of yesterday's scores at the start of, say, the 8th inning, in case you just watch the final innings of the closest games without spoilers.
- when spoilers are hidden, the addon now hides whether games are in the bottom of the 9th or extras -- now it just says "9th+"
- suspended/resumed games/streams are now labeled so you can tell them apart
- game icons/fanarts/descriptions are now passed through as variables too, so they can be displayed for games no matter how you access them (previously, they wouldn't show up for "Catch Up" games, or streams accessed through a context menu)