### PR TITLE
MiLB and recap/highlight/catchup improvements

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2023.4.14+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2023.6.6+matrix.1" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -22,11 +22,10 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - fixed bug on stream select for games without video
-            - fixed data source for game changer
-            - use full team names for non-MLB teams
-            - added MiLB (minor league) games
-            - added country setting for better labeling international blackouts
+            - added affiliate and level menus for finding MiLB (minor league) games
+            - fixed play all recaps / condensed games behavior when clicking on date
+            - start at inning / automatic skip for minor league games
+            - show only in-game highlights for play all highlights or catch up
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ fanart = None
 featured_video = None
 description = None
 sport = MLB_ID
+teams = 'None'
 
 if 'name' in params:
     name = urllib.unquote_plus(params["name"])
@@ -63,6 +64,9 @@ if 'description' in params:
 if 'sport' in params:
     sport = urllib.unquote_plus(params["sport"])
 
+if 'teams' in params:
+    teams = urllib.unquote_plus(params["teams"])
+
 # default addon home screen
 if mode is None:
     # autoplay fav team, if that setting is enabled and a live broadcast is in progress
@@ -77,11 +81,11 @@ if mode is None:
 
 # Today's Games
 elif mode == 100:
-    todays_games(None, start_inning, sport)
+    todays_games(None, start_inning, sport, teams)
 
 # Prev and Next
 elif mode == 101:
-    todays_games(game_day, start_inning, sport)
+    todays_games(game_day, start_inning, sport, teams)
 
 # autoplay, use an extra parameter to force auto stream selection
 elif mode == 102:
@@ -122,9 +126,13 @@ elif mode == 108:
     # Refresh will erase history, so navigating back won't bring up the inning prompt again
     xbmc.executebuiltin('Container.Refresh("plugin://plugin.video.mlbtv/?mode=101&game_day='+game_day+'&start_inning='+str(start_inning)+'")')
 
-# MiLB Games
+# MiLB Games menu
 elif mode == 109:
-    todays_games(None, start_inning, "11,12,13,14,16")
+    minor_league_categories()
+
+# By Affiliate menu
+elif mode == 110:
+    affiliate_menu()
 
 # Goto Date
 elif mode == 200:
@@ -148,7 +156,7 @@ elif mode == 300:
 
 # Featured stream select
 elif mode == 301:
-    featured_stream_select(featured_video, name, description)
+    featured_stream_select(featured_video, name, description, start_inning, game_pk)
 
 # Logout
 elif mode == 400:

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -376,3 +376,32 @@ msgctxt "#30428"
 msgid "Country (for blackout labels)"
 msgstr ""
 
+msgctxt "#30429"
+msgid "By Affiliate"
+msgstr ""
+
+msgctxt "#30430"
+msgid "AAA"
+msgstr ""
+
+msgctxt "#30431"
+msgid "AA"
+msgstr ""
+
+msgctxt "#30432"
+msgid "A+"
+msgstr ""
+
+msgctxt "#30433"
+msgid "A"
+msgstr ""
+
+msgctxt "#30434"
+msgid "Skip adjust in seconds (negative, earlier; positive, later)"
+msgstr ""
+
+msgctxt "#30435"
+msgid "Extra MiLB skip adjust (seconds)"
+msgstr ""
+
+

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -104,7 +104,7 @@ MLB_ID = '1'
 MILB_IDS = '11,12,13,14'
 MLB_TEAM_IDS = '108,109,110,111,112,113,114,115,116,117,118,119,120,121,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,158,159,160'
 
-AFFILIATE_TEAM_IDS = {"Los Angeles Angels":"401,559,460,561","Arizona Diamondbacks":"419,516,2310,5368","Baltimore Orioles":"418,568,548,488","Boston Red Sox":"428,414,533,546","Chicago Cubs":"521,451,550,553","Cincinnati Reds":"450,459,498,416","Cleveland Guardians":"445,402,437,481","Colorado Rockies":"259,486,342,538","Detroit Tigers":"512,570,582,106","Houston Astros":"482,5434,573,3712","Kansas City Royals":"1350,3705,541,565","Los Angeles Dodgers":"260,238,456,526","Washington Nationals":"436,534,547,426","New York Mets":"453,507,552,505","Oakland Athletics":"237,499,400,524","Pittsburgh Pirates":"3390,484,452,477","San Diego Padres":"103,510,584,4904","Seattle Mariners":"403,515,529,574","San Francisco Giants":"105,461,476,3410","St. Louis Cardinals":"279,235,440,443","Tampa Bay Rays":"2498,233,234,421","Texas Rangers":"102,485,540,448","Toronto Blue Jays":"424,435,463,422","Minnesota Twins":"492,509,1960,3898","Philadelphia Phillies":"427,522,1410,566","Atlanta Braves":"430,432,478,431","Chicago White Sox":"247,580,487,494","Miami Marlins":"479,564,554,4124","New York Yankees":"1956,587,531,537","Milwaukee Brewers":"249,572,556,5015"}
+AFFILIATE_TEAM_IDS = {"Arizona Diamondbacks": "419,516,2310,5368", "Atlanta Braves": "430,432,478,431", "Baltimore Orioles": "418,568,548,488", "Boston Red Sox": "428,414,533,546", "Chicago Cubs": "521,451,550,553", "Chicago White Sox": "247,580,487,494", "Cincinnati Reds": "450,459,498,416", "Cleveland Guardians": "445,402,437,481", "Colorado Rockies": "259,486,342,538", "Detroit Tigers": "512,570,582,106", "Houston Astros": "482,5434,573,3712", "Kansas City Royals": "1350,3705,541,565", "Los Angeles Angels": "401,559,460,561", "Los Angeles Dodgers": "260,238,456,526", "Miami Marlins": "479,564,554,4124", "Milwaukee Brewers": "249,572,556,5015", "Minnesota Twins": "492,509,1960,3898", "New York Mets": "453,507,552,505", "New York Yankees": "1956,587,531,537", "Oakland Athletics": "237,499,400,524", "Philadelphia Phillies": "427,522,1410,566", "Pittsburgh Pirates": "3390,484,452,477", "San Diego Padres": "103,510,584,4904", "Seattle Mariners": "403,515,529,574", "San Francisco Giants": "105,461,476,3410", "St. Louis Cardinals": "279,235,440,443", "Tampa Bay Rays": "2498,233,234,421", "Texas Rangers": "102,485,540,448", "Toronto Blue Jays": "424,435,463,422", "Washington Nationals": "436,534,547,426"}
 
 ESPN_SUNDAY_NIGHT_BLACKOUT_COUNTRIES = ["Angola", "Anguilla", "Antigua and Barbuda", "Argentina", "Aruba", "Australia", "Bahamas", "Barbados", "Belize", "Belize", "Benin", "Bermuda", "Bolivia", "Bonaire", "Botswana", "Brazil", "British Virgin Islands", "Burkina Faso", "Burundi", "Cameroon", "Cape Verde", "Cayman Islands", "Central African Republic", "Chad", "Chile", "Colombia", "Comoros", "Cook Islands", "Costa Rica", "Cote d'Ivoire", "Curacao", "Democratic Republic of the Congo", "Djibouti", "Dominica", "Dominican Republic", "Ecuador", "El Salvador", "England", "Equatorial Guinea", "Eritrea", "Eswatini", "Ethiopia", "Falkland Islands", "Falkland Islands", "Fiji", "French Guiana", "French Guiana", "French Polynesia", "Gabon", "Ghana", "Grenada", "Guadeloupe", "Guatemala", "Guinea", "Guinea Bissau", "Guyana", "Guyana", "Haiti", "Honduras", "Ireland", "Jamaica", "Kenya", "Kiribati", "Lesotho", "Liberia", "Madagascar", "Malawi", "Mali", "Marshall Islands", "Martinique", "Mayotte", "Mexico", "Micronesia", "Montserrat", "Mozambique", "Namibia", "Netherlands", "New Zealand", "Nicaragua", "Niger", "Nigeria", "Niue", "Northern Ireland", "Palau Islands", "Panama", "Paraguay", "Peru", "Republic of Ireland", "Reunion", "Rwanda", "Saba", "Saint Maarten", "Samoa", "Sao Tome & Principe", "Scotland", "Senegal", "Seychelles", "Sierra Leone", "Solomon Islands", "Somalia", "South Africa", "St. Barthelemy", "St. Eustatius", "St. Kitts and Nevis", "St. Lucia", "St. Martin", "St. Vincent and the Grenadines", "Sudan", "Surinam", "Suriname", "Tahiti", "Tanzania & Zanzibar", "The Gambia", "The Republic of Congo", "Togo", "Tokelau", "Tonga", "Trinidad and Tobago", "Turks and Caicos Islands", "Tuvalu", "Uganda", "Uruguay", "Venezuela", "Wales", "Zambia", "Zimbabwe"]
 
@@ -217,7 +217,7 @@ def add_stream(name, title, desc, game_pk, icon=None, fanart=None, info=None, vi
     ok=True
 
     if milb is not None:
-        u_params = "&featured_video="+urllib.quote_plus("https://dai.tv.milb.com/api/v2/playback-info/games/"+str(game_pk)+"/contents/14862/products/milb-carousel")+"&name="+urllib.quote_plus(title)+"&description="+urllib.quote_plus(desc)
+        u_params = "&featured_video="+urllib.quote_plus("https://dai.tv.milb.com/api/v2/playback-info/games/"+str(game_pk)+"/contents/14862/products/milb-carousel")+"&name="+urllib.quote_plus(title)+"&description="+urllib.quote_plus(desc)+"&game_pk="+urllib.quote_plus(str(game_pk))+"&start_inning="+urllib.quote_plus(str(start_inning))
         u=sys.argv[0]+"?mode="+str(301)+u_params
     else:
         u_params = "&name="+urllib.quote_plus(title)+"&game_pk="+urllib.quote_plus(str(game_pk))+"&stream_date="+urllib.quote_plus(str(stream_date))+"&spoiler="+urllib.quote_plus(str(spoiler))+"&suspended="+urllib.quote_plus(str(suspended))+"&start_inning="+urllib.quote_plus(str(start_inning))+"&description="+urllib.quote_plus(desc)+"&blackout="+urllib.quote_plus(str(blackout))
@@ -274,10 +274,10 @@ def addLink(name,url,title,icon,info=None,video_info=None,audio_info=None,fanart
     return ok
 
 
-def addDir(name,mode,icon,fanart=None,game_day=None,start_inning='False',sport=MLB_ID):
+def addDir(name,mode,icon,fanart=None,game_day=None,start_inning='False',sport=MLB_ID,teams='None'):
     ok=True
 
-    u_params="&name="+urllib.quote_plus(name)+"&icon="+urllib.quote_plus(icon)+'&start_inning='+urllib.quote_plus(str(start_inning))+'&sport='+urllib.quote_plus(str(sport))
+    u_params="&name="+urllib.quote_plus(name)+"&icon="+urllib.quote_plus(icon)+'&start_inning='+urllib.quote_plus(str(start_inning))+'&sport='+urllib.quote_plus(str(sport))+'&teams='+urllib.quote_plus(str(teams))
     if game_day is not None:
         u_params = u_params+"&game_day="+urllib.quote_plus(game_day)
     u=sys.argv[0]+"?mode="+str(mode)+u_params
@@ -501,6 +501,32 @@ def get_last_name(full_name):
     except:
         pass
     return last_name
+
+
+def get_broadcast_start_timestamp(stream_url):
+    broadcast_start_timestamp = None
+    is_live = True
+    try:
+        url = stream_url[:len(stream_url)-5] + '_1280x720_59_5472K.m3u8'
+        headers = {
+            'User-Agent': UA_PC,
+             'Origin': 'https://www.mlb.com',
+             'Referer': 'https://www.mlb.com/'
+        }
+        r = requests.get(url, headers=headers, verify=VERIFY)
+        content = r.text
+        line_array = content.splitlines()
+        for line in line_array:
+            if line.startswith('#EXT-X-PLAYLIST-TYPE:VOD'):
+                is_live = False
+            elif line.startswith('#EXT-X-PROGRAM-DATE-TIME:'):
+                broadcast_start_timestamp = parse(line[25:])
+                xbmc.log('Found broadcast start timestamp ' + str(broadcast_start_timestamp))
+                break
+    except:
+        xbmc.log('Failed to find broadcast start timestamp')
+        pass
+    return broadcast_start_timestamp, is_live
 
 
 # get the teams blacked out based on zip code

--- a/resources/lib/mlbmonitor.py
+++ b/resources/lib/mlbmonitor.py
@@ -834,7 +834,7 @@ class MLBMonitor(xbmc.Monitor):
             xbmc.log("MLB Monitor from " + self.mlb_monitor_started + " closing due to another monitor starting on " + new_mlb_monitor_started)
             self.mlb_monitor_started = ''
 
-    def skip_monitor(self, skip_type, game_pk, broadcast_start_timestamp, stream_url, is_live, start_inning, start_inning_half):
+    def skip_monitor(self, skip_type, game_pk, broadcast_start_timestamp, skip_adjust, stream_url, is_live, start_inning, start_inning_half):
         xbmc.log("Skip monitor for " + game_pk + " starting")
 
         self.mlb_monitor_started = str(datetime.now())
@@ -848,7 +848,7 @@ class MLBMonitor(xbmc.Monitor):
 
         # fetch skip markers
         self.skip_to_players = None
-        skip_markers, self.skip_to_players = self.get_skip_markers(skip_type, game_pk, broadcast_start_timestamp, monitor_name, self.skip_to_players, stream_url, 0, start_inning, start_inning_half)
+        skip_markers, self.skip_to_players = self.get_skip_markers(skip_type, game_pk, broadcast_start_timestamp, skip_adjust, monitor_name, self.skip_to_players, stream_url, 0, start_inning, start_inning_half)
         xbmc.log(monitor_name + ' skip markers : ' + str(skip_markers))
 
         while not self.monitor.abortRequested():
@@ -895,7 +895,7 @@ class MLBMonitor(xbmc.Monitor):
                         # refresh current time, and look ahead slightly
                         current_time = player.getTime() + 10
                         xbmc.log(monitor_name + ' refreshing skip markers from ' + str(current_time))
-                        skip_markers, self.skip_to_players = self.get_skip_markers(skip_type, game_pk, broadcast_start_timestamp, monitor_name, self.skip_to_players, stream_url, current_time)
+                        skip_markers, self.skip_to_players = self.get_skip_markers(skip_type, game_pk, broadcast_start_timestamp, skip_adjust, monitor_name, self.skip_to_players, stream_url, current_time)
                         xbmc.log(monitor_name + ' refreshed skip markers : ' + str(skip_markers))
             else:
                 if self.stream_started == False:
@@ -941,7 +941,7 @@ class MLBMonitor(xbmc.Monitor):
 
 
     # calculate skip markers from gameday events
-    def get_skip_markers(self, skip_type, game_pk, broadcast_start_timestamp, monitor_name, skip_to_players, stream_url, current_time=0, start_inning=0, start_inning_half='top'):
+    def get_skip_markers(self, skip_type, game_pk, broadcast_start_timestamp, skip_adjust, monitor_name, skip_to_players, stream_url, current_time=0, start_inning=0, start_inning_half='top'):
         xbmc.log(monitor_name + ' getting skip markers for skip type ' + str(skip_type))
         if current_time > 0:
             xbmc.log(monitor_name + ' searching beyond ' + str(current_time))
@@ -954,6 +954,10 @@ class MLBMonitor(xbmc.Monitor):
         settings = xbmcaddon.Addon(id='plugin.video.mlbtv')
         skip_adjust_start = int(settings.getSetting(id="skip_adjust_start"))
         skip_adjust_end = int(settings.getSetting(id="skip_adjust_end"))
+
+        # extra skip adjust (for MiLB games)
+        skip_adjust_start += skip_adjust
+        skip_adjust_end += skip_adjust
 
         # calculate total skip time (for fun)
         total_skip_time = 0

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -31,8 +31,9 @@
     <setting id="auto_select_stream" type="bool" label="30307" default="false" />
     <setting id="catch_up" type="bool" label="30304" default="true" />
     <setting id="ask_to_skip" type="bool" label="30306" default="true" />
-    <setting id="skip_adjust_start" type="labelenum" label="30424" default="0" values="-7|-6|-5|-4|-3|-2|-1|0|1|2|3|4|5|6|7" />
-    <setting id="skip_adjust_end" type="labelenum" label="30425" default="0" values="-7|-6|-5|-4|-3|-2|-1|0|1|2|3|4|5|6|7" />
+    <setting id="skip_adjust_start" type="labelenum" label="30424" default="0" values="-10|-9|-8|-7|-6|-5|-4|-3|-2|-1|0|1|2|3|4|5|6|7|8|9|10" />
+    <setting id="skip_adjust_end" type="labelenum" label="30425" default="0" values="-10|-9|-8|-7|-6|-5|-4|-3|-2|-1|0|1|2|3|4|5|6|7|8|9|10" />
+    <setting id="milb_skip_adjust" type="labelenum" label="30435" default="-5" values="Always Ask|-15|-10|-5|0|5|10|15" />
     <setting id="auto_play_fav" type="bool" label="30412" default="false" />
     <setting id="only_free_games" type="bool" label="30305" default="false" />
     <setting id="game_changer_delay" type="labelenum" label="30420" default="0" values="0|10|20" />


### PR DESCRIPTION
- added affiliate and level menus for finding MiLB (minor league) games
- fixed play all recaps / condensed games behavior when clicking on date
- start at inning / automatic skip for minor league games
- show only in-game highlights for play all highlights or catch up