### PR TITLE
fixed stream padding to avoid timeline spoilers

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2023.10.11+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2024.3.1+matrix.1" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -22,7 +22,7 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - improve settings type
+            - fixed stream padding to avoid timeline spoilers
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/resources/lib/mlb.py
+++ b/resources/lib/mlb.py
@@ -961,17 +961,18 @@ def stream_select(game_pk, spoiler='True', suspended='False', start_inning='Fals
         # if not live and no spoilers and not audio, generate a random number of segments to pad at end of proxy stream url
         elif DISABLE_VIDEO_PADDING == 'false' and is_live is False and spoiler == 'False' and stream_type != 'audio':
             pad = random.randint((3600 / SECONDS_PER_SEGMENT), (7200 / SECONDS_PER_SEGMENT))
-            headers += '&pad=' + str(pad)
-            stream_url = 'http://127.0.0.1:43670/' + stream_url
+            # pass padding as URL querystring parameter
+            stream_url = 'http://127.0.0.1:43670/' + stream_url + '?pad=' + str(pad)
 
-        # add alternate audio tracks, if necessary
+        # add extra alternate audio tracks, if necessary
         if DISABLE_VIDEO_PADDING == 'false' and (alternate_english is not None or alternate_spanish is not None):
-            if alternate_english is not None:
-                headers += '&alternate_english=' + urllib.quote_plus(alternate_english)
-            if alternate_spanish is not None:
-                headers += '&alternate_spanish=' + urllib.quote_plus(alternate_spanish)
+            # pass any extra alternate audio tracks as URL querystring parameters
             if not stream_url.startswith('http://127.0.0.1:43670/'):
-                stream_url = 'http://127.0.0.1:43670/' + stream_url
+                stream_url = 'http://127.0.0.1:43670/' + stream_url + '?'
+            if alternate_english is not None:
+                stream_url += '&alternate_english=' + urllib.quote_plus(alternate_english)
+            if alternate_spanish is not None:
+                stream_url += '&alternate_spanish=' + urllib.quote_plus(alternate_spanish)
 
         # valid stream url
         if '.m3u8' in stream_url:


### PR DESCRIPTION
Stream padding (to hide timeline spoilers) was failing on some systems -- see [here](https://www.reddit.com/r/MLBtv/comments/1bj1q7w/mlbtv_spoilers/)

Switching the padding variable from a HTTP request header to a URL query string parameter fixes it.

This pull request also makes the same switch for any extra alternate audio tracks, to avoid similar trouble.