### PR TITLE
require IA; improve stream padding; Omega fix

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -27,6 +27,7 @@
             - updated affiliates list
             - require InputStream Adaptive
             - more graceful stream padding
+            - potential Omega compatibility fix
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/addon.xml
+++ b/addon.xml
@@ -26,6 +26,7 @@
             - fixed Big Inning schedule
             - updated affiliates list
             - require InputStream Adaptive
+            - more graceful stream padding
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/addon.xml
+++ b/addon.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2024.3.28+matrix.1" provider-name="eracknaphobia, tonywagner">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2024.3.29+matrix.1" provider-name="eracknaphobia, tonywagner">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
         <import addon="script.module.beautifulsoup4" />
         <import addon="script.module.requests" />
-        <import addon="inputstream.adaptive" optional="true"/>
+        <import addon="inputstream.adaptive"/>
         <import addon="script.module.kodi-six" />
         <import addon="script.module.dateutil" />
     </requires>
@@ -25,6 +25,7 @@
             - further fixed stream padding to avoid timeline spoilers
             - fixed Big Inning schedule
             - updated affiliates list
+            - require InputStream Adaptive
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/resources/lib/globals.py
+++ b/resources/lib/globals.py
@@ -441,8 +441,13 @@ def stream_to_listitem(stream_url, headers, description, title, icon, fanart, st
                 listitem.setProperty('inputstream', 'inputstream.adaptive')
             else:
                 listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
+            # IA manifest_type deprecated in Kodi 20, may eventually need to remove this
+            # but will need to ensure manifest type can be auto-detected from streams and proxied streams
             listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')
             listitem.setProperty('inputstream.adaptive.stream_headers', headers)
+            # IA stream_headers deprecated for manifests in Kodi 20, manifest_headers required in Kodi 21+
+            if KODI_VERSION >= 20:
+                listitem.setProperty('inputstream.adaptive.manifest_headers', headers)
             listitem.setProperty('inputstream.adaptive.license_key', "|" + headers)
             # if not using Kodi's resume function, set the start time
             if sys.argv[3] != 'resume:true' and start != '-1':

--- a/service.py
+++ b/service.py
@@ -120,17 +120,19 @@ class RequestHandler(BaseHTTPRequestHandler):
         if new_line_array[last_item_index] == ENDLIST_TEXT and int(pad) > 0:
             new_line_array.pop()
             last_item_index -= 1
-            url_line = None
+            #url_line = None
             extinf_line = None
             while extinf_line is None:
                 if new_line_array[last_item_index].startswith('#EXTINF:5'):
                     extinf_line = new_line_array[last_item_index]
-                    url_line = new_line_array[last_item_index+1]
+                    #url_line = new_line_array[last_item_index+1]
                     break
                 last_item_index -= 1
             for x in range(0, pad):
                 new_line_array.append(extinf_line)
-                new_line_array.append(url_line)
+                # use base proxy URL for more graceful stream padding, instead of repeating last segment
+                #new_line_array.append(url_line)
+                new_line_array.append(PROXY_URL)
             new_line_array.append(ENDLIST_TEXT)
 
         content = "\n".join(new_line_array)


### PR DESCRIPTION
InputStream Adaptive is now required rather than optional, since so many features depend on it.

Instead of repeating the last segment to pad the streams, the internal proxy now just points to its own URL. This causes Kodi to simply stop when the padding is reached, which is the desired behavior, rather than repeatedly downloading the same segment and potentially locking up.

"manifest_headers" are now sent to InputStream Adaptive separately from stream_headers to [satisfy its changes in Kodi v21 Omega](https://github.com/xbmc/inputstream.adaptive/wiki/Integration#inputstreamadaptivestream_headers).

Tested on Windows, Mac (Intel), and Android.

